### PR TITLE
Document and harden dotfiles tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # akgm dotfiles
 
-[![Last Commit](https://img.shields.io/github/last-commit/akgm3i/.dotfiles)](https://github.com/akgm3i/.dotfiles/commits/main)
+[![Last Commit](https://img.shields.io/github/last-commit/akgm3i/.dotfiles)](https://github.com/akgm3i/.dotfiles/commits/master)
 
 
 ## About
@@ -16,11 +16,12 @@ Ubuntu (WSL) / macOS
 - Sheldon: シェルプラグインマネージャー
 - Tmux: ターミナルマルチプレクサ
 - Zsh: shell
+- Bash: shell
 
 ## インストール
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/refs/heads/master/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/master/install.sh | bash
 ```
 
 ### インストール内容
@@ -41,7 +42,11 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/refs/heads/master/
     *   .dotfiles内の設定ファイルやディレクトリへのシンボリックリンクを `$XDG_CONFIG_HOME` や `$HOME` 配下に作成する。
     *   既存のファイルやディレクトリがある場合、それらは `$XDG_DATA_HOME/dotfiles/backup_YYYYMMDDHHMMSS/` 以下にバックアップする。
 
-4.  デフォルトシェルのZshへの変更:
+4.  追加ツールのインストール:
+    *   `mise` と `sheldon` が未導入の場合はインストールする。
+    *   `mise` のグローバル設定を trust し、定義されたツールをインストールする。
+
+5.  デフォルトシェルのZshへの変更:
     *   デフォルトシェルがZshでない場合、Zshに変更する。
     *   パスワードの入力が求められることがある。
 
@@ -54,7 +59,7 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/refs/heads/master/
 
 > 例: ~/src/github.com/akgm3i/.dotfiles にインストールする場合
 > ```bash
-> curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/main/install.sh | DOTPATH="$HOME/src/github.com/akgm3i/.dotfiles" bash
+> curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/master/install.sh | DOTPATH="$HOME/src/github.com/akgm3i/.dotfiles" bash
 > ```
 
 ## アンインストール
@@ -74,7 +79,7 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/refs/heads/master/
 - [zsh-users/zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting): Fish shell like syntax highlighting for Zsh
 
 ### Aliases
-#### Common aliases
+#### Common aliases (shared with Bash)
 ##### ls
 
 | Alias | Command | Description |
@@ -97,6 +102,48 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/refs/heads/master/
 | Alias | Command | Description |
 | :--- | :--- | :--- |
 | `cat` | `bat` | Display file content with bat |
+
+## Bash設定
+- `~/.config/bash/[0-9][0-9]_*.bash` を `plugins.bash.toml` で定義した `sheldon` プロファイルから読み込む。
+- `shell/env.sh` に共通の環境変数をまとめており、Zsh/Bash 双方で共有。
+- 共通エイリアスは `shell/aliases.sh` に定義している。
+
+### Sheldon profiles
+
+| Shell | Config | Loaded items |
+| :--- | :--- | :--- |
+| Zsh | `sheldon/plugins.toml` | `pure`, `zsh-completions`, `zsh-defer`, `zsh-autosuggestions`, `zsh-syntax-highlighting`, `~/.config/zsh/[0-9][0-9]_*.zsh` |
+| Bash | `sheldon/plugins.bash.toml` | `~/.config/bash/[0-9][0-9]_*.bash` |
+
+## Mise設定
+
+`mise/config.toml` で以下のツールと言語ランタイムを管理する。
+
+### Tools
+
+| Tool | Version | Purpose |
+| :--- | :--- | :--- |
+| `bat` | `latest` | `cat` 代替のファイル表示 |
+| `npm:@openai/codex` | `latest` | OpenAI Codex CLI |
+| `eza` | `latest` | `ls` 代替のファイル一覧 |
+| `fd` | `latest` | ファイル検索 |
+| `fzf` | `latest` | fuzzy finder |
+| `gemini` | `latest` | Gemini CLI |
+| `gh` | `latest` | GitHub CLI |
+| `ghq` | `latest` | repository manager |
+| `jq` | `latest` | JSON processor |
+| `usage` | `latest` | CLI usage helper |
+
+### Languages
+
+| Runtime | Version |
+| :--- | :--- |
+| `deno` | `2.5` |
+| `go` | `1.25` |
+| `node` | `22` |
+| `python` | `3.13` |
+| `rust` | `1.89` |
+
 
 ## Applications
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,4 @@
+- [ ] Protect sensitive tokens (e.g., GitHub) via external secrets or environment, not committed files.
+- [ ] Ensure XDG_RUNTIME_DIR (/home/akgm3i/.temp) is created (install script) before tmux uses it.
+- [ ] Respect externally supplied DOTPATH in .zshenv (use exported default).
+- [ ] Cache or defer mise outdated/version checks in motd to avoid slowdown.

--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -1,0 +1,11 @@
+#
+# Login shell configuration for Bash.
+#
+
+if [ -r "$HOME/.bashrc" ]; then
+  . "$HOME/.bashrc"
+fi
+
+if [ -r "$HOME/.bash_profile.local" ]; then
+  . "$HOME/.bash_profile.local"
+fi

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -40,7 +40,7 @@ fi
 
 # History configuration
 HISTDIR="$XDG_STATE_HOME/bash"
-mkdir -p "$HISTDIR"
+[ -d "$HISTDIR" ] || mkdir -p "$HISTDIR"
 export HISTFILE="$HISTDIR/history"
 export HISTSIZE=10000
 export HISTFILESIZE=200000

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -1,0 +1,69 @@
+#
+# Executes commands at the start of an interactive Bash session.
+#
+
+# Skip when not interactive.
+case $- in
+  *i*) ;;
+  *) return ;;
+esac
+
+umask 022
+ulimit -S -c 0 2>/dev/null || true
+
+if [ -z "${DOTPATH:-}" ]; then
+  _dotfiles_bashrc="${BASH_SOURCE[0]}"
+  case "$_dotfiles_bashrc" in
+    /*) ;;
+    *) _dotfiles_bashrc="$PWD/$_dotfiles_bashrc" ;;
+  esac
+  if [ -L "$_dotfiles_bashrc" ] && command -v readlink >/dev/null 2>&1; then
+    _dotfiles_bashrc_target="$(readlink "$_dotfiles_bashrc")"
+    case "$_dotfiles_bashrc_target" in
+      /*) _dotfiles_bashrc="$_dotfiles_bashrc_target" ;;
+      *) _dotfiles_bashrc="$(dirname "$_dotfiles_bashrc")/$_dotfiles_bashrc_target" ;;
+    esac
+  fi
+  _dotfiles_candidate="$(cd "$(dirname "$_dotfiles_bashrc")/.." 2>/dev/null && pwd -P)"
+  if [ -r "$_dotfiles_candidate/shell/env.sh" ]; then
+    DOTPATH="$_dotfiles_candidate"
+  else
+    DOTPATH="$HOME/.dotfiles"
+  fi
+  unset _dotfiles_bashrc _dotfiles_bashrc_target _dotfiles_candidate
+fi
+export DOTPATH
+
+if [ -r "$DOTPATH/shell/env.sh" ]; then
+  . "$DOTPATH/shell/env.sh"
+fi
+
+# History configuration
+HISTDIR="$XDG_STATE_HOME/bash"
+mkdir -p "$HISTDIR"
+export HISTFILE="$HISTDIR/history"
+export HISTSIZE=10000
+export HISTFILESIZE=200000
+shopt -s histappend cmdhist checkwinsize
+
+########
+# mise #
+########
+if command -v mise >/dev/null 2>&1; then
+  eval "$(mise activate bash)"
+fi
+
+###########
+# sheldon #
+###########
+if command -v sheldon >/dev/null 2>&1; then
+  eval "$( \
+    SHELDON_CONFIG_FILE="${XDG_CONFIG_HOME}/sheldon/plugins.bash.toml" \
+    sheldon source
+  )"
+fi
+
+# Load local settings if present.
+if [ -r "$HOME/.bashrc.local" ]; then
+  . "$HOME/.bashrc.local"
+fi

--- a/bash/20_aliases.bash
+++ b/bash/20_aliases.bash
@@ -1,0 +1,8 @@
+# shellcheck shell=bash
+#
+# Source shared aliases.
+#
+
+if [ -r "$DOTPATH/shell/aliases.sh" ]; then
+  . "$DOTPATH/shell/aliases.sh"
+fi

--- a/bin/motd
+++ b/bin/motd
@@ -87,69 +87,45 @@ EOF
     }
 
     _get_git_info() {
-        # Get Git status for dotfiles
-        local repo_path="$ZDOTDIR"
+        local repo_path="${DOTPATH:-$HOME/.dotfiles}"
         if ! git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
             return
         fi
 
-        # --- Asynchronous, cached fetch using FETCH_HEAD ---
-        # To keep data fresh without slowing login, trigger a background fetch if
-        # the last fetch was more than 1 hour ago. We use .git/FETCH_HEAD's
-        # modification time as the most reliable source for the last fetch time.
-        local fetch_head_file="$repo_path/.git/FETCH_HEAD"
-        local fetch_interval_seconds=3600 # 1 hour
-        local last_fetch_time=0
+        local fetch_head_file last_fetch_time=0
+        fetch_head_file=$(git -C "$repo_path" rev-parse --git-path FETCH_HEAD 2>/dev/null)
+        [[ "$fetch_head_file" == /* ]] || fetch_head_file="$repo_path/$fetch_head_file"
 
-        if [[ -f "$fetch_head_file" ]]; then
-            # Cross-platform way to get modification time (epoch seconds)
-            if command -v stat >/dev/null; then
-                if [[ "$(uname)" == "Darwin" ]]; then # macOS
-                    last_fetch_time=$(stat -f %m "$fetch_head_file")
-                else # Linux
-                    last_fetch_time=$(stat -c %Y "$fetch_head_file")
-                fi
+        if [[ -f "$fetch_head_file" ]] && command -v stat >/dev/null; then
+            if [[ "$(uname)" == "Darwin" ]]; then
+                last_fetch_time=$(stat -f %m "$fetch_head_file")
+            else
+                last_fetch_time=$(stat -c %Y "$fetch_head_file")
             fi
         fi
 
         local current_time
         current_time=$(date +%s)
 
-        if (( (current_time - last_fetch_time) > fetch_interval_seconds )); then
-            # Run fetch in the background for the next login.
-            # It's safe to run this concurrently; git handles the locking.
-            # Fetch only the master branch to avoid unnecessary remote refs.
-            (git -C "$repo_path" fetch origin master >/dev/null 2>&1 &)
+        if (( current_time - last_fetch_time > 3600 )); then
+            (git -C "$repo_path" fetch origin refs/heads/master:refs/remotes/origin/master >/dev/null 2>&1 &)
         fi
 
-        # --- Git Status Calculation ---
-        # The rest of the function proceeds immediately, using currently available
-        # data for a fast motd. The background fetch will benefit subsequent logins.
-
-        # 1. Check for local changes
         local local_changes
         local_changes=$(git -C "$repo_path" status --porcelain)
 
-        # 2. Check for remote changes (ahead/behind)
-        local ahead=0 behind=0
-        local upstream
-        upstream=$(git -C "$repo_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)
+        local ahead=0 behind=0 counts
 
-        if [[ -n "$upstream" ]]; then
-            local counts
-            counts=$(git -C "$repo_path" rev-list --left-right --count "$upstream...HEAD" 2>/dev/null)
-            if [[ $? -eq 0 && -n "$counts" ]]; then
-                behind=$(echo "$counts" | awk '{print $1}')
-                ahead=$(echo "$counts" | awk '{print $2}')
-            fi
+        if git -C "$repo_path" rev-parse --verify --quiet master >/dev/null \
+            && git -C "$repo_path" rev-parse --verify --quiet origin/master >/dev/null \
+            && counts=$(git -C "$repo_path" rev-list --left-right --count origin/master...master 2>/dev/null); then
+            read behind ahead <<< "$counts"
         fi
 
-        # 3. If everything is clean, return nothing.
         if [[ -z "$local_changes" && "$ahead" -eq 0 && "$behind" -eq 0 ]]; then
             return
         fi
 
-        # 4. Build the status string
         local -a status_parts
         if [[ -n "$local_changes" ]]; then
             status_parts+=("${fg_bold[red]}Uncommitted changes${reset_color}")

--- a/bin/motd
+++ b/bin/motd
@@ -118,8 +118,8 @@ EOF
         if (( (current_time - last_fetch_time) > fetch_interval_seconds )); then
             # Run fetch in the background for the next login.
             # It's safe to run this concurrently; git handles the locking.
-            # We fetch only the main branch from origin for efficiency.
-            (git -C "$repo_path" fetch origin main >/dev/null 2>&1 &)
+            # Fetch only the master branch to avoid unnecessary remote refs.
+            (git -C "$repo_path" fetch origin master >/dev/null 2>&1 &)
         fi
 
         # --- Git Status Calculation ---
@@ -172,6 +172,25 @@ EOF
     pkg_info=$(_get_pkg_info)
     git_status=$(_get_git_info)
 
+    local os_info system_info uptime_info display_value
+    if (( $+commands[lsb_release] )); then
+        os_info=$(lsb_release -d 2>/dev/null | awk -F'\t' '{print $2}')
+    fi
+    if [[ -z "$os_info" ]] && (( $+commands[sw_vers] )); then
+        os_info="$(sw_vers -productName) $(sw_vers -productVersion)"
+    fi
+    os_info=${os_info:-$(uname -s)}
+
+    system_info=$(uname -srm 2>/dev/null || uname -s)
+
+    uptime_info=$(uptime -p 2>/dev/null)
+    if [[ -z "$uptime_info" ]]; then
+        uptime_info=$(uptime 2>/dev/null)
+    fi
+    uptime_info=${uptime_info:-unknown}
+
+    display_value=${DISPLAY:-"-"}
+
     # Get mise outdated info
     if (( $+commands[mise] )); then
         local -a mise_updates
@@ -206,10 +225,10 @@ EOF
         "$(whoami)"
         "$(hostname)"
         "$ZSH_VERSION"
-        "$DISPLAY"
-        "$(lsb_release -d | awk -F'\t' '{print $2}')"
-        "$(uname -srm)"
-        "$(uptime -p)"
+        "$display_value"
+        "$os_info"
+        "$system_info"
+        "$uptime_info"
     )
 
     if [[ -n "$mem_info" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,10 @@ setup_dotpath
 unset -f setup_dotpath
 
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-"$HOME/.config"}
+XDG_CACHE_HOME=${XDG_CACHE_HOME:-"$HOME/.cache"}
 XDG_DATA_HOME=${XDG_DATA_HOME:-"$HOME/.local/share"}
+XDG_STATE_HOME=${XDG_STATE_HOME:-"$HOME/.local/state"}
+XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-"$HOME/.temp"}
 
 # --- Globals ---
 backup_dir=""
@@ -139,7 +142,8 @@ create_symlinks() {
     log_info "Creating symbolic links..."
 
     # Ensure target directories exist
-    mkdir -p "$XDG_CONFIG_HOME"
+    mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR"
+    chmod 700 "$XDG_RUNTIME_DIR" 2>/dev/null || true
 
     local symlinks=(
         "$DOTPATH/git:$XDG_CONFIG_HOME/git"
@@ -149,6 +153,9 @@ create_symlinks() {
         "$DOTPATH/sheldon:$XDG_CONFIG_HOME/sheldon"
         "$DOTPATH/mise:$XDG_CONFIG_HOME/mise"
         "$DOTPATH/npm:$XDG_CONFIG_HOME/npm"
+        "$DOTPATH/bash:$XDG_CONFIG_HOME/bash"
+        "$DOTPATH/bash/.bashrc:$HOME/.bashrc"
+        "$DOTPATH/bash/.bash_profile:$HOME/.bash_profile"
         "$DOTPATH/zsh/.zshenv:$HOME/.zshenv"
     )
 
@@ -188,6 +195,36 @@ create_symlinks() {
 
 install_tools() {
     log_info "Installing additional tools..."
+
+    local local_bin="$HOME/.local/bin"
+    mkdir -p "$local_bin"
+
+    local mise_bin="$local_bin/mise"
+    if ! has mise && [ ! -x "$mise_bin" ]; then
+        log_info "Installing mise..."
+        curl https://mise.run | sh
+    fi
+
+    if [ -x "$mise_bin" ]; then
+        local mise_config="$XDG_CONFIG_HOME/mise/config.toml"
+        if [ -r "$mise_config" ]; then
+            "$mise_bin" trust "$mise_config"
+        fi
+        "$mise_bin" install
+    elif has mise; then
+        local mise_config="$XDG_CONFIG_HOME/mise/config.toml"
+        if [ -r "$mise_config" ]; then
+            mise trust "$mise_config"
+        fi
+        mise install
+    fi
+
+    local sheldon_bin="$local_bin/sheldon"
+    if ! has sheldon && [ ! -x "$sheldon_bin" ]; then
+        log_info "Installing sheldon..."
+        curl --proto '=https' -fLsS https://rossmacarthur.github.io/install/crate.sh \
+            | bash -s -- --repo rossmacarthur/sheldon --to "$local_bin"
+    fi
 }
 
 switch_shell_to_zsh() {

--- a/install.sh
+++ b/install.sh
@@ -202,7 +202,7 @@ install_tools() {
     local mise_bin="$local_bin/mise"
     if ! has mise && [ ! -x "$mise_bin" ]; then
         log_info "Installing mise..."
-        curl https://mise.run | sh
+        curl -fsSL https://mise.run | sh
     fi
 
     if [ -x "$mise_bin" ]; then

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,6 +1,7 @@
 [tools]
 # tools
 bat = "latest"
+"npm:@openai/codex" = "latest"
 eza = "latest"
 fd = "latest"
 fzf = "latest"
@@ -11,7 +12,7 @@ jq = "latest"
 usage = "latest"
 
 # languages
-deno = "2.4"
+deno = "2.5"
 go = "1.25"
 node = "22"
 python = "3.13"

--- a/sheldon/plugins.bash.toml
+++ b/sheldon/plugins.bash.toml
@@ -1,0 +1,5 @@
+shell = 'bash'
+
+[plugins.custom]
+local = '~/.config/bash'
+use = ['[0-9][0-9]_*.bash']

--- a/shell/aliases.sh
+++ b/shell/aliases.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=sh
+#
+# Shared aliases for POSIX-compatible shells.
+#
+
+alias ..='cd ../'
+alias ls='eza --git --icons'
+alias ld='eza -ld'
+alias ll='eza -lF'
+alias la='eza -aF'
+alias lla='eza -laF'
+alias lx='eza -lXB'
+alias lk='eza -lSr'
+alias lt='eza -ltr'
+alias lc='eza -ltcr'
+alias lu='eza -ltur'
+alias lr='eza -lR'
+alias cat='bat'

--- a/shell/env.sh
+++ b/shell/env.sh
@@ -57,8 +57,15 @@ export MISE_RUSTUP_HOME="$XDG_DATA_HOME/rustup"
 export MISE_CARGO_HOME="$XDG_DATA_HOME/cargo"
 
 # History directories can be handled per-shell, but ensure base directories exist.
-mkdir -p "$XDG_STATE_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$XDG_RUNTIME_DIR"
-chmod 700 "$XDG_RUNTIME_DIR" 2>/dev/null || true
+for _xdg_dir in "$XDG_STATE_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME"; do
+  [ -d "$_xdg_dir" ] || mkdir -p "$_xdg_dir"
+done
+unset _xdg_dir
+
+if [ ! -d "$XDG_RUNTIME_DIR" ]; then
+  mkdir -p "$XDG_RUNTIME_DIR"
+  chmod 700 "$XDG_RUNTIME_DIR" 2>/dev/null || true
+fi
 
 # Configure fzf defaults if available.
 export FZF_DEFAULT_OPTS="${FZF_DEFAULT_OPTS:---extended --ansi --multi}"
@@ -67,7 +74,7 @@ export INTERACTIVE_FILTER="${INTERACTIVE_FILTER:-fzf:peco:percol:gof:pick}"
 # Helper to prepend directories to PATH without duplicates.
 _path_prepend() {
   case ":$PATH:" in
-    *":$1:") return 0 ;;
+    *":$1:"*) return 0 ;;
   esac
 
   if [ -d "$1" ]; then
@@ -79,10 +86,10 @@ _path_prepend() {
   fi
 }
 
-_path_prepend "$HOME/bin"
-_path_prepend "$HOME/.local/bin"
-_path_prepend "$DOTPATH/bin"
 _path_prepend /usr/local/bin
+_path_prepend "$DOTPATH/bin"
+_path_prepend "$HOME/.local/bin"
+_path_prepend "$HOME/bin"
 export PATH
 
 unset -f _path_prepend

--- a/shell/env.sh
+++ b/shell/env.sh
@@ -1,0 +1,88 @@
+# shellcheck shell=sh
+#
+# Shared environment configuration for POSIX-compatible shells.
+#
+
+# Ensure DOTPATH is set so other scripts can reference the dotfiles repo.
+if [ -z "${DOTPATH:-}" ]; then
+  DOTPATH="$HOME/.dotfiles"
+fi
+export DOTPATH
+
+# XDG Base Directory defaults (allow user overrides).
+: "${XDG_CONFIG_HOME:=$HOME/.config}"
+: "${XDG_CACHE_HOME:=$HOME/.cache}"
+: "${XDG_DATA_HOME:=$HOME/.local/share}"
+: "${XDG_STATE_HOME:=$HOME/.local/state}"
+: "${XDG_RUNTIME_DIR:=$HOME/.temp}"
+export XDG_CONFIG_HOME XDG_CACHE_HOME XDG_DATA_HOME XDG_STATE_HOME XDG_RUNTIME_DIR
+
+# Editor / pager
+: "${EDITOR:=nvim}"
+export EDITOR
+export CVSEDITOR="$EDITOR"
+export SVN_EDITOR="$EDITOR"
+export GIT_EDITOR="$EDITOR"
+export PAGER="${PAGER:-less}"
+
+# Locale
+export LANGUAGE="${LANGUAGE:-en_US.UTF-8}"
+export LANG="$LANGUAGE"
+export LC_ALL="$LANGUAGE"
+export LC_CTYPE="$LANGUAGE"
+
+# Less configuration
+export LESS='-R -f -X -i -P ?f%f:(stdin). ?lb%lb?L/%L.. [?eEOF:?pb%pb\%..]'
+export LESSCHARSET='utf-8'
+export LESS_TERMCAP_mb='\E[01;31m'
+export LESS_TERMCAP_md='\E[01;31m'
+export LESS_TERMCAP_me='\E[0m'
+export LESS_TERMCAP_se='\E[0m'
+export LESS_TERMCAP_so='\E[00;44;37m'
+export LESS_TERMCAP_ue='\E[0m'
+export LESS_TERMCAP_us='\E[01;32m'
+
+# Colors
+export LSCOLORS="${LSCOLORS:-exfxcxdxbxegedabagacad}"
+export LS_COLORS="${LS_COLORS:-di=34:ln=35:so=32:pi=33:ex=31:bd=46;34:cd=43;34:su=41;30:sg=46;30:tw=42;30:ow=43;30}"
+
+# Tool-specific configuration
+export TMUX_HOME="$DOTPATH/tmux"
+export TMUX_TMPDIR="$XDG_RUNTIME_DIR"
+export GHQ_ROOT="${GHQ_ROOT:-$HOME/Projects}"
+export GOPATH="${GOPATH:-$XDG_DATA_HOME/go}"
+export NODE_REPL_HISTORY="$XDG_DATA_HOME/node_repl_history"
+export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
+export MISE_RUSTUP_HOME="$XDG_DATA_HOME/rustup"
+export MISE_CARGO_HOME="$XDG_DATA_HOME/cargo"
+
+# History directories can be handled per-shell, but ensure base directories exist.
+mkdir -p "$XDG_STATE_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR" 2>/dev/null || true
+
+# Configure fzf defaults if available.
+export FZF_DEFAULT_OPTS="${FZF_DEFAULT_OPTS:---extended --ansi --multi}"
+export INTERACTIVE_FILTER="${INTERACTIVE_FILTER:-fzf:peco:percol:gof:pick}"
+
+# Helper to prepend directories to PATH without duplicates.
+_path_prepend() {
+  case ":$PATH:" in
+    *":$1:") return 0 ;;
+  esac
+
+  if [ -d "$1" ]; then
+    if [ -n "$PATH" ]; then
+      PATH="$1:$PATH"
+    else
+      PATH="$1"
+    fi
+  fi
+}
+
+_path_prepend "$HOME/bin"
+_path_prepend "$HOME/.local/bin"
+_path_prepend "$DOTPATH/bin"
+_path_prepend /usr/local/bin
+export PATH
+
+unset -f _path_prepend

--- a/tests/test_shell_startup.sh
+++ b/tests/test_shell_startup.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local test_name="$3"
+
+  if [ "$expected" = "$actual" ]; then
+    printf 'PASS: %s\n' "$test_name"
+  else
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "$test_name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+test_zsh_dotpath_from_symlink() {
+  if ! command -v zsh >/dev/null 2>&1; then
+    printf 'SKIP: zsh is not installed\n'
+    return
+  fi
+
+  local home output dotpath runtime_dir
+  home="$TEST_DIR/zsh-home"
+  mkdir -p "$home"
+  ln -s "$REPO_ROOT/zsh/.zshenv" "$home/.zshenv"
+
+  output="$(
+    env -u DOTPATH -u ZDOTDIR -u XDG_RUNTIME_DIR HOME="$home" zsh -c \
+      'printf "%s\n%s\n" "$DOTPATH" "$XDG_RUNTIME_DIR"; test -d "$XDG_RUNTIME_DIR"'
+  )"
+  dotpath="$(printf '%s\n' "$output" | sed -n '1p')"
+  runtime_dir="$(printf '%s\n' "$output" | sed -n '2p')"
+
+  assert_eq "$REPO_ROOT" "$dotpath" "zsh resolves DOTPATH from .zshenv symlink"
+  assert_eq "$home/.temp" "$runtime_dir" "zsh creates default XDG_RUNTIME_DIR"
+}
+
+test_bash_dotpath_from_symlink() {
+  local home output dotpath runtime_dir
+  home="$TEST_DIR/bash-home"
+  mkdir -p "$home"
+  ln -s "$REPO_ROOT/bash/.bashrc" "$home/.bashrc"
+
+  output="$(
+    env -u DOTPATH -u XDG_RUNTIME_DIR HOME="$home" bash -ic \
+      'printf "__DOTPATH__%s\n__RUNTIME__%s\n" "$DOTPATH" "$XDG_RUNTIME_DIR"; test -d "$XDG_RUNTIME_DIR"' \
+      2>/dev/null
+  )"
+  dotpath="$(printf '%s\n' "$output" | sed -n 's/^__DOTPATH__//p')"
+  runtime_dir="$(printf '%s\n' "$output" | sed -n 's/^__RUNTIME__//p')"
+
+  assert_eq "$REPO_ROOT" "$dotpath" "bash resolves DOTPATH from .bashrc symlink"
+  assert_eq "$home/.temp" "$runtime_dir" "bash creates default XDG_RUNTIME_DIR"
+}
+
+test_zsh_dotpath_from_symlink
+test_bash_dotpath_from_symlink

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -30,6 +30,9 @@ remove_symlinks() {
         "$XDG_CONFIG_HOME/gh"
         "$XDG_CONFIG_HOME/npm"
         "$XDG_CONFIG_HOME/iterm2"
+        "$XDG_CONFIG_HOME/bash"
+        "$HOME/.bashrc"
+        "$HOME/.bash_profile"
         "$HOME/.zshenv"
     )
 
@@ -65,16 +68,19 @@ restore_backup() {
         # In interactive mode, let the user choose
         log_info "Available backups:"
         select backup_dir in "${backup_dirs[@]}" "Skip restoration"; do
-            if [ "$REPLY" == "Skip restoration" ] || [ -z "$REPLY" ]; then
+            if [ -z "$backup_dir" ]; then
+                log_error "Invalid selection."
+                continue
+            fi
+            if [ "$backup_dir" = "Skip restoration" ]; then
                 log_info "Skipping restoration."
                 return
             fi
             if [ -d "$backup_dir" ]; then
-                backup_to_restore=$backup_dir
+                backup_to_restore="$backup_dir"
                 break
-            else
-                log_error "Invalid selection."
             fi
+            log_error "Invalid selection."
         done
     fi
 

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,103 +1,58 @@
 #
-# Defines environment variables.
+# Defines environment variables for Zsh.
 #
 
-# XDG Base Directory
-export XDG_CONFIG_HOME=${HOME}/.config
-export XDG_CACHE_HOME=${HOME}/.cache
-export XDG_DATA_HOME=${HOME}/.local/share
-export XDG_STATE_HOME=${HOME}/.local/state
-export XDG_RUNTIME_DIR=${HOME}/.temp
+# Avoid sourcing /etc/zshenv when possible.
+setopt no_global_rcs
 
-# DOTPATH
-export DOTPATH=${HOME}/.dotfiles
+# Ensure DOTPATH is available before loading shared configuration.
+if [[ -z ${DOTPATH:-} ]]; then
+    _dotfiles_zshenv_file="${ZDOTDIR:-$HOME}/.zshenv"
+    if [[ -L "${_dotfiles_zshenv_file}" ]] && command -v readlink >/dev/null 2>&1; then
+        _dotfiles_zshenv_target="$(readlink "${_dotfiles_zshenv_file}")"
+        if [[ "${_dotfiles_zshenv_target}" == /* ]]; then
+            _dotfiles_zshenv_file="${_dotfiles_zshenv_target}"
+        else
+            _dotfiles_zshenv_file="${_dotfiles_zshenv_file:h}/${_dotfiles_zshenv_target}"
+        fi
+    fi
+    _dotfiles_zshenv_dir="$(cd "${_dotfiles_zshenv_file:h}" 2>/dev/null && pwd -P)"
+    if [[ -n "${_dotfiles_zshenv_dir}" ]]; then
+        _dotfiles_zshenv_file="${_dotfiles_zshenv_dir}/${_dotfiles_zshenv_file:t}"
+    fi
+    _dotfiles_candidate="${_dotfiles_zshenv_file:h:h}"
+    if [[ -r "${_dotfiles_candidate}/shell/env.sh" ]]; then
+        export DOTPATH="${_dotfiles_candidate}"
+    else
+        export DOTPATH=${HOME}/.dotfiles
+    fi
+    unset _dotfiles_zshenv_file _dotfiles_zshenv_target _dotfiles_zshenv_dir _dotfiles_candidate
+fi
+
+# Load shared, POSIX-compatible environment configuration.
+if [[ -r "${DOTPATH}/shell/env.sh" ]]; then
+    source "${DOTPATH}/shell/env.sh"
+fi
+
+# Zsh-specific directories and history configuration.
 export ZDOTDIR=${XDG_CONFIG_HOME}/zsh
-
-# History
-# History file
 export HISTFILE=${XDG_STATE_HOME}/zsh/history
-# History size in memory
 export HISTSIZE=10000
-# The number of histsize
 export SAVEHIST=1000000
-# The size of asking history
 export LISTMAX=50
-# Do not save history when running as root
+
 if [[ ${UID} -eq 0 ]]; then
     unset HISTFILE
     export SAVEHIST=0
 fi
 
-# LANGUAGE
-export LANGUAGE='en_US.UTF-8'
-export LANG=${LANGUAGE}
-export LC_ALL=${LANGUAGE}
-export LC_CTYPE=${LANGUAGE}
-
-# Editor
-export EDITOR=nvim
-export CVSEDITOR=${EDITOR}
-export SVN_EDITOR=${EDITOR}
-export GIT_EDITOR=${EDITOR}
-
-# Pager
-export PAGER=less
-
-# Less status line
-export LESS='-R -f -X -i -P ?f%f:(stdin). ?lb%lb?L/%L.. [?eEOF:?pb%pb\%..]'
-export LESSCHARSET='utf-8'
-
-# LESS man page colors (makes Man pages more readable).
-export LESS_TERMCAP_mb=$'\E[01;31m'
-export LESS_TERMCAP_md=$'\E[01;31m'
-export LESS_TERMCAP_me=$'\E[0m'
-export LESS_TERMCAP_se=$'\E[0m'
-export LESS_TERMCAP_so=$'\E[00;44;37m'
-export LESS_TERMCAP_ue=$'\E[0m'
-export LESS_TERMCAP_us=$'\E[01;32m'
-
-# ls command colors
-export LSCOLORS=exfxcxdxbxegedabagacad
-export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=46;34:cd=43;34:su=41;30:sg=46;30:tw=42;30:ow=43;30'
-
-# declare the environment variables
+# Spell correction configuration.
 export CORRECT_IGNORE='_*'
 export CORRECT_IGNORE_FILE='.*'
 
+# Word characters used when moving across words.
 export WORDCHARS='*?_-.[]~=&;!#$%^(){}<>'
 
-# fzf - command-line fuzzy finder (https://github.com/junegunn/fzf)
-export FZF_DEFAULT_OPTS="--extended --ansi --multi"
-
-# available $INTERACTIVE_FILTER
-export INTERACTIVE_FILTER="fzf:peco:percol:gof:pick"
-
-# tmux
-export TMUX_HOME=${DOTPATH}/tmux
-export TMUX_TMPDIR=${XDG_RUNTIME_DIR}
-
-# ghq
-export GHQ_ROOT=${HOME}/Projects
-
-# Programing Languages
-# Settings for Go
-export GOPATH=${XDG_DATA_HOME}/go
-
-# Settings for Node.js
-export NODE_REPL_HISTORY=${XDG_DATA_HOME}/node_repl_history
-export NPM_CONFIG_USERCONFIG=${XDG_CONFIG_HOME}/npm/npmrc
-
-# Settings for Rust
-export MISE_RUSTUP_HOME=${XDG_DATA_HOME}/rustup
-export MISE_CARGO_HOME=${XDG_DATA_HOME}/cargo
-
-# PATH
-setopt no_global_rcs
-typeset -gx -U path
-path=( \
-    ${HOME}/bin(N-/) \
-    ${HOME}/.local/bin \
-    ${DOTPATH}/bin(N-/) \
-    /usr/local/bin(N-/) \
-    ${path} \
-    )
+# Ensure PATH stays unique when converted to the Zsh array form.
+typeset -gU path
+path=(${(s/:/)PATH})

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -17,32 +17,17 @@ fi
 ########
 # mise #
 ########
-if [[ ! -f ${HOME}/.local/bin/mise ]]; then
-    # Install mise if not found
-    echo "mise not found. Installing..."
-    curl https://mise.run | sh
-    mise trust ${MISE_GLOBAL_CONFIG_FILE}
-    mise install
-    echo "mise installed."
+if command -v mise >/dev/null 2>&1; then
+    eval "$(mise activate zsh)"
 fi
-
-# activate mise
-eval "$(mise activate zsh)"
 
 
 ###########
 # sheldon #
 ###########
-if [[ ! -x ${HOME}/.local/bin/sheldon ]]; then
-    # Install sheldon if not found
-    echo "sheldon not found. Installing..."
-    curl --proto '=https' -fLsS https://rossmacarthur.github.io/install/crate.sh \
-        | bash -s -- --repo rossmacarthur/sheldon --to "${HOME}/.local/bin"
-    echo "sheldon installed."
+if command -v sheldon >/dev/null 2>&1; then
+    eval "$(sheldon source)"
 fi
-
-# activate sheldon
-eval "$(sheldon source)"
 
 
 # load local settings

--- a/zsh/30_aliases.zsh
+++ b/zsh/30_aliases.zsh
@@ -2,20 +2,6 @@
 # Defines aliases.
 #
 
-#- Common aliases
-##- ls
-alias ..='cd ../'          # Move to parent directory
-alias ls='eza --git --icons' # List files with eza (git & icons)
-alias ld='eza -ld'          # Show info about the directory
-alias ll='eza -lF'          # Show long file information
-alias la='eza -aF'          # Show hidden files
-alias lla='eza -laF'        # Show hidden all files
-alias lx='eza -lXB'         # Sort by extension
-alias lk='eza -lSr'         # Sort by size, biggest last
-alias lt='eza -ltr'         # Sort by date, most recent last
-alias lc='eza -ltcr'        # Sort by and show change time, most recent last
-alias lu='eza -ltur'        # Sort by and show access time, most recent last
-alias lr='eza -lR'          # Recursive ls
-
-##- cat
-alias cat='bat'             # Display file content with bat
+if [[ -r "${DOTPATH}/shell/aliases.sh" ]]; then
+    source "${DOTPATH}/shell/aliases.sh"
+fi

--- a/zsh/80_custom.zsh
+++ b/zsh/80_custom.zsh
@@ -21,8 +21,17 @@ autoload -Uz compinit && compinit -d "${XDG_CACHE_HOME}/zsh/zcompdump-${ZSH_VERS
 zstyle ':completion:*' cache-path $XDG_CACHE_HOME/zsh/zcompcache
 
 function cdrepo {
-  local repodir="$( ghq list -p | fzf -1 +m )"
+  local repodir="$( ghq list -p | fzf -1 +m --query "${*:-}" )"
   if [ ! -z "$repodir" ] ; then
     cd "$repodir"
   fi
+}
+
+function cddot {
+  local target="${DOTPATH:-}"
+  if [ -z "$target" ] || [ ! -d "$target" ]; then
+    printf 'cddot: DOTPATH directory is unavailable\n' >&2
+    return 1
+  fi
+  cd "$target"
 }

--- a/zsh/99_deinit.zsh
+++ b/zsh/99_deinit.zsh
@@ -5,8 +5,9 @@
 # Source any secret files.
 ()
 {
-    local f
-    for f in ./*secret*.zsh(N-.)
+    local f secret_dir
+    secret_dir="${ZDOTDIR:-${DOTPATH:-$HOME/.dotfiles}/zsh}"
+    for f in "${secret_dir}"/*secret*.zsh(N-.)
     do
         source "$f"
     done


### PR DESCRIPTION
## Summary

- Add Bash support alongside Zsh with shared shell environment and aliases
- Move mise/sheldon installation responsibility into `install.sh`
- Harden shell startup by resolving `DOTPATH` from symlinks and limiting secret file loading to the Zsh config directory
- Document Sheldon profiles and mise-managed tools/runtimes in README
- Add startup regression tests for Zsh/Bash `DOTPATH` and `XDG_RUNTIME_DIR`

## Why

The previous setup mixed installer responsibilities into interactive shell startup and assumed `$HOME/.dotfiles` as the repo location. That made alternate `DOTPATH` installs fragile and allowed secret files to be sourced from the current working directory.

## Validation

- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n bash/.bashrc tests/test_shell_startup.sh`
- `zsh -n zsh/.zshenv zsh/.zshrc zsh/99_deinit.zsh`
- `./tests/test_update_script.sh`
- `./tests/test_shell_startup.sh`
