### PR TITLE
Make MOTD local and opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,14 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/master/install.sh 
 
 `install.sh` を実行した際のバックアップを復元する。
 
+## MOTD
+
+`motd` を実行すると、端末とdotfilesのローカル情報を表示する。
+シェル起動時には実行されない。起動時表示を明示的に有効化する場合は、
+環境変数 `DOTFILES_MOTD_ON_START=1` を設定する。
+
 ## Zsh設定
+
 ### Plugins
 - [romkatv/zsh-defer](https://github.com/romkatv/zsh-defer): Deferred loading of plugins in Zsh
 - [sindresorhus/pure](https://github.com/sindresorhus/pure): Pretty, minimal and fast ZSH prompt

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
 - [ ] Protect sensitive tokens (e.g., GitHub) via external secrets or environment, not committed files.
 - [ ] Ensure XDG_RUNTIME_DIR (/home/akgm3i/.temp) is created (install script) before tmux uses it.
 - [ ] Respect externally supplied DOTPATH in .zshenv (use exported default).
-- [ ] Cache or defer mise outdated/version checks in motd to avoid slowdown.

--- a/bin/motd
+++ b/bin/motd
@@ -1,366 +1,133 @@
 #!/usr/bin/env zsh
-#
-# This script displays a motd.
-#
 
-()
-{
-    # --- Definitions ---
-    local lspider_body sspider_body
-    lspider_body=$(cat << 'EOF'
-              ,     :
-            ,'      :     '.
-          ,;        :      ';,
-        ,:'         :        ':.
-        ::          :         ;:
-       ,:       ,,,,,,,,,      ::
-       ::     .:::::::::::.    ::
-    ,  ::    :::::::::::::::   ::
-   ;   ::   :::::::▄▄▄:::::::  ':   .
-  ;    ::   ::::::▐█:▀█::::::   :;   ;
- :'    ::   ::::::▄█▀▀█::::::   :;    ;
-::     ':.  ::::::▐█:▪▐▌:::::  ,:     ::
-';.     ';;:;::::::▀::▀:::::;,;''    .:'
- ::         ';:::::::::::::;'        ::
-  ::.         '::;:::::;::'          :;
-   ;:.   ,.,,;;';:::::::;';;,,,.    ,:'
-    ':::'''' ,,';:::::::;",, '':::::;'
-        ,,,,;' ,;:::::::;, ':,,
-     ,,;"'   .:: ':::::' ;:   ";;,,
-   .:'      .:;   ;""";  ':.     "';.
-   :;      :;:            ';,      ::
-   ;      :;.               ;:     ::
-   ::    :;                  ;:    ::
-    '.  ,;                    ;:  .'
-     '  ::                    ::  '
-       ,:;                    ::.
-       ::'                     :;
-       ::                      ::
-       ::                      ::
-        ;:                    :;
-         ';                  ;'
-           ;                ;
-EOF
-)
-    sspider_body=$(cat << 'EOF'
-  / _ \
-\_\(A)/_/
- _//o\\_
-  /   \
-EOF
-)
+# Display a compact, local-only system summary.
+emulate -L zsh
+setopt no_aliases pipe_fail
 
-    # Load zsh colors
-    autoload -Uz colors && colors
+# Zsh maintains LINES and COLUMNS without an external tput call. Check them
+# before collecting system or repository information.
+local terminal_lines="${LINES:-24}"
+local terminal_columns="${COLUMNS:-80}"
+[[ "$terminal_lines" == <-> ]] || terminal_lines=24
+[[ "$terminal_columns" == <-> ]] || terminal_columns=80
 
-    # --- Helper Functions for System Info ---
-    _get_mem_info() {
-        if (( $+functions[is_linux] )) && is_linux && (( $+commands[free] )); then
-            free -h | awk 'NR==2{printf "%s/%s", $3, $2}'
-        elif (( $+functions[is_osx] )) && is_osx && (( $+commands[top] )); then
-            top -l 1 | grep "PhysMem:" | awk '{print $2 " used, " $6 " unused"}'
-        fi
-    }
+if (( terminal_lines < 10 || terminal_columns < 72 )); then
+    exit 0
+fi
 
-    _get_disk_info() {
-        if (( $+commands[df] )); then
-            df -h / | awk 'NR==2{printf "%s/%s (%s)", $3, $2, $5}'
-        fi
-    }
+_motd_os_info() {
+    local key value
 
-    _get_pkg_info() {
-        if (( $+functions[is_linux] )) && is_linux && [[ -x /usr/lib/update-notifier/apt-check ]]; then
-            local updates
-            updates=$(/usr/lib/update-notifier/apt-check 2>&1)
-            local num_updates=$(echo "$updates" | cut -d';' -f1)
-            local num_security=$(echo "$updates" | cut -d';' -f2)
-            if (( num_updates > 0 || num_security > 0 )); then
-                echo "${fg_bold[yellow]}${num_updates} updates, ${num_security} security updates${reset_color}"
+    if [[ -r /etc/os-release ]]; then
+        while IFS='=' read -r key value; do
+            if [[ "$key" == PRETTY_NAME ]]; then
+                value="${value#\"}"
+                value="${value%\"}"
+                print -r -- "$value"
+                return
             fi
-        elif (( $+functions[is_osx] )) && is_osx && (( $+commands[brew] )); then
-            local num_outdated
-            num_outdated=$(brew outdated | wc -l | tr -d ' ')
-            if (( num_outdated > 0 )); then
-                echo "${fg_bold[yellow]}${num_outdated} packages can be updated${reset_color}"
-            fi
-        fi
-    }
-
-    _get_git_info() {
-        local repo_path="${DOTPATH:-$HOME/.dotfiles}"
-        if ! git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            return
-        fi
-
-        local fetch_head_file last_fetch_time=0
-        fetch_head_file=$(git -C "$repo_path" rev-parse --git-path FETCH_HEAD 2>/dev/null)
-        [[ "$fetch_head_file" == /* ]] || fetch_head_file="$repo_path/$fetch_head_file"
-
-        if [[ -f "$fetch_head_file" ]] && command -v stat >/dev/null; then
-            if [[ "$(uname)" == "Darwin" ]]; then
-                last_fetch_time=$(stat -f %m "$fetch_head_file")
-            else
-                last_fetch_time=$(stat -c %Y "$fetch_head_file")
-            fi
-        fi
-
-        local current_time
-        current_time=$(date +%s)
-
-        if (( current_time - last_fetch_time > 3600 )); then
-            (git -C "$repo_path" fetch origin refs/heads/master:refs/remotes/origin/master >/dev/null 2>&1 &)
-        fi
-
-        local local_changes
-        local_changes=$(git -C "$repo_path" status --porcelain)
-
-        local ahead=0 behind=0 counts
-
-        if git -C "$repo_path" rev-parse --verify --quiet master >/dev/null \
-            && git -C "$repo_path" rev-parse --verify --quiet origin/master >/dev/null \
-            && counts=$(git -C "$repo_path" rev-list --left-right --count origin/master...master 2>/dev/null); then
-            read behind ahead <<< "$counts"
-        fi
-
-        if [[ -z "$local_changes" && "$ahead" -eq 0 && "$behind" -eq 0 ]]; then
-            return
-        fi
-
-        local -a status_parts
-        if [[ -n "$local_changes" ]]; then
-            status_parts+=("${fg_bold[red]}Uncommitted changes${reset_color}")
-        fi
-        if (( behind > 0 )); then
-            status_parts+=("${fg[yellow]}Behind by $behind${reset_color}")
-        fi
-        if (( ahead > 0 )); then
-            status_parts+=("${fg[yellow]}Ahead by $ahead${reset_color}")
-        fi
-
-        # Join with commas and print
-        echo "${(j/, /)status_parts}"
-    }
-
-    # --- Get System Info ---
-    local mem_info disk_info pkg_info git_status
-    mem_info=$(_get_mem_info)
-    disk_info=$(_get_disk_info)
-    pkg_info=$(_get_pkg_info)
-    git_status=$(_get_git_info)
-
-    local os_info system_info uptime_info display_value
-    if (( $+commands[lsb_release] )); then
-        os_info=$(lsb_release -d 2>/dev/null | awk -F'\t' '{print $2}')
-    fi
-    if [[ -z "$os_info" ]] && (( $+commands[sw_vers] )); then
-        os_info="$(sw_vers -productName) $(sw_vers -productVersion)"
-    fi
-    os_info=${os_info:-$(uname -s)}
-
-    system_info=$(uname -srm 2>/dev/null || uname -s)
-
-    uptime_info=$(uptime -p 2>/dev/null)
-    if [[ -z "$uptime_info" ]]; then
-        uptime_info=$(uptime 2>/dev/null)
-    fi
-    uptime_info=${uptime_info:-unknown}
-
-    display_value=${DISPLAY:-"-"}
-
-    # Get mise outdated info
-    if (( $+commands[mise] )); then
-        local -a mise_updates
-        local num_outdated
-        num_outdated=$(mise outdated 2>/dev/null | grep -c . || true)
-        if (( num_outdated > 0 )); then
-            mise_updates+=("${fg_bold[yellow]}${num_outdated} packages can be updated${reset_color}")
-        fi
-
-        # Get mise self-update info
-        if (mise version 2>&1 | grep -q 'available'); then
-            mise_updates+=("${fg_bold[red]}mise self-update is available${reset_color}")
-        fi
-
-        if (( ${#mise_updates} > 0 )); then
-            local mise_info="${(j/, /)mise_updates}"
-        fi
+        done < /etc/os-release
     fi
 
-    # --- Prepare MOTD data ---
-    local -a labels values
-    labels=(
-        "User"
-        "Host"
-        "Zsh"
-        "DISPLAY on"
-        "OS"
-        "System"
-        "Uptime"
-    )
-    values=(
-        "$(whoami)"
-        "$(hostname)"
-        "$ZSH_VERSION"
-        "$display_value"
-        "$os_info"
-        "$system_info"
-        "$uptime_info"
-    )
-
-    if [[ -n "$mem_info" ]]; then
-        labels+=("Memory")
-        values+=("$mem_info")
-    fi
-    if [[ -n "$disk_info" ]]; then
-        labels+=("Disk (/)")
-        values+=("$disk_info")
-    fi
-
-    if [[ -n "$git_status" ]]; then
-        labels+=("Dotfiles")
-        values+=("$git_status")
-    fi
-
-    if [[ -n "$mise_info" ]]; then
-        labels+=("Mise")
-        values+=("$mise_info")
-    fi
-
-    if [[ -n "$pkg_info" ]]; then
-        labels+=("Packages")
-        values+=("$pkg_info")
-    fi
-
-    # --- Format MOTD ---
-    local -a motd
-    local max_label_width=0
-    local label
-    for label in "${labels[@]}"; do
-        (( ${#label} > max_label_width )) && max_label_width=${#label}
-    done
-
-    # Add 2 characters for padding after the longest label.
-    (( max_label_width += 1 ))
-
-    local i
-    for ((i = 1; i <= ${#labels}; i++)); do
-        motd+=("$(printf "${fg_bold[cyan]}%-${max_label_width}s: ${fg_bold[magenta]}%s${reset_color}" "${labels[$i]}" "${values[$i]}")")
-    done
-
-    # --- Helper Functions ---
-
-    # Escape backslashes for echo -e.
-    _escape_for_echo() {
-        # Replace every backslash with a double backslash.
-        print -r -- "${1//\\/\\\\}"
-    }
-
-    # Get the visible width of a string (stripping ANSI codes).
-    _get_string_width() {
-        local rendered_line
-        rendered_line=$(print -nrP -- "$1")
-        echo ${#rendered_line}
-    }
-
-    # Get the maximum width from a multi-line string.
-    _get_max_width() {
-        # Return 0 if input is empty.
-        if [[ -z "$1" ]]; then
-            echo 0
-            return
-        fi
-
-        local max_width=0 line width
-        # Use a while-read loop for robustness instead of parameter expansion.
-        while IFS= read -r line; do
-            width=$(_get_string_width "$line")
-            (( width > max_width )) && max_width=$width
-        done <<< "$1"
-        echo $max_width
-    }
-
-    # --- ANSI Color Functions ---
-    # Generate a line of ANSI colors for display.
-    _generate_color_line() {
-        local normal_colors=""
-        local bright_colors=""
-        local color_name
-
-        # Normal foreground colors (0-7)
-        for color_name in black red green yellow blue magenta cyan white; do
-            normal_colors+="${fg[$color_name]}██"
-        done
-        # Bright/bold foreground colors (8-15)
-        for color_name in black red green yellow blue magenta cyan white; do
-            bright_colors+="${fg_bold[$color_name]}██"
-        done
-
-        print -r -- "${normal_colors}${reset_color}"
-        print -r -- "${bright_colors}${reset_color}"
-    }
-
-     # --- Main Logic --s
-     # Select the appropriate spider based on terminal height.
-    local spider_art spider_thread_art
-    local lspider_height=${#${(f)lspider_body}}
-    local sspider_height=${#${(f)sspider_body}}
-    local prompt_margin=3
-
-    if (( LINES > lspider_height + prompt_margin )); then
-        spider_art=$lspider_body
-        spider_thread_art='                    :'
-    elif (( LINES > sspider_height + prompt_margin )); then
-        spider_art=$sspider_body
-        spider_thread_art='    |'
-    else
-        # Not enough space for any art.
+    if (( $+commands[sw_vers] )); then
+        print -r -- "$(sw_vers -productName) $(sw_vers -productVersion)"
         return
     fi
 
-    # --- Calculate Dimensions ---
-    local display_height=$((LINES - prompt_margin))
-    local art_margin=2
-    local art_width=$(( $(_get_max_width "$spider_art") + art_margin * 2 ))
-    local message_margin=4
-    local message_width=$((COLUMNS - art_width - message_margin * 2))
-
-    # --- Prepare Content ---
-    local art_lines=("${(@f)spider_art}")
-    local art_height=${#art_lines}
-    local thread_height=$((display_height - art_height))
-    local message_padding_top=$(( (display_height - ${#motd}) / 2 ))
-
-    # --- Draw Content ---
-    # Pre-generate color bars to be used in the loop.
-    local -a color_bars
-    color_bars=("${(@f)$(_generate_color_line)}")
-
-    local i=1
-    local art_pane message_pane
-    for ((i = 1; i <= display_height; i++)); do
-        # Art Pane
-        art_pane=""
-        if (( i > thread_height )); then
-            local art_line_index=$((i - thread_height))
-            if (( art_line_index <= art_height )); then
-                 art_pane="$(printf "%*s" $art_margin "")$(_escape_for_echo "${art_lines[art_line_index]}")"
-            fi
-        else
-            art_pane="$(printf "%*s" $art_margin "")$(_escape_for_echo "${spider_thread_art}")"
-        fi
-        art_pane="$(printf "%-${art_width}s" "$art_pane")"
-
-        # Message Pane
-        message_pane=""
-        local message_line_index=$((i - message_padding_top))
-        if (( message_line_index > 0 && message_line_index <= ${#motd} )); then
-            message_pane="$(printf "%*s" $message_margin "")${motd[message_line_index]}"
-        elif (( message_line_index == ${#motd} + 3 )); then
-            message_pane="$(printf "%*s" $message_margin "")${color_bars[1]}"
-        elif (( message_line_index == ${#motd} + 4 )); then
-            message_pane="$(printf "%*s" $message_margin "")${color_bars[2]}"
-        fi
-
-        echo -e "${art_pane}${message_pane}"
-    done
+    uname -s 2>/dev/null
 }
+
+_motd_git_info() {
+    local repo_path="${DOTPATH:-$HOME/.dotfiles}"
+    local branch upstream dirty counts
+    integer ahead=0 behind=0
+
+    (( $+commands[git] )) || return
+    [[ -d "$repo_path/.git" || -f "$repo_path/.git" ]] || return
+    git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return
+
+    branch=$(git -C "$repo_path" symbolic-ref --short -q HEAD 2>/dev/null)
+    if [[ -z "$branch" ]]; then
+        branch=$(git -C "$repo_path" rev-parse --short HEAD 2>/dev/null)
+    fi
+    [[ -n "$branch" ]] || return
+
+    dirty=$(git -C "$repo_path" status --porcelain --untracked-files=normal 2>/dev/null)
+
+    if upstream=$(git -C "$repo_path" rev-parse \
+        --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null) \
+        && [[ -n "$upstream" ]] \
+        && counts=$(git -C "$repo_path" rev-list --left-right --count \
+            'HEAD...@{upstream}' 2>/dev/null); then
+        read -r ahead behind <<< "$counts"
+    fi
+
+    local repo_status="$branch"
+    [[ -n "$dirty" ]] && repo_status+=", dirty"
+    (( ahead > 0 )) && repo_status+=", ahead $ahead"
+    (( behind > 0 )) && repo_status+=", behind $behind"
+    print -r -- "$repo_status"
+}
+
+local os_info kernel_info uptime_info disk_info git_info
+os_info=$(_motd_os_info)
+kernel_info=$(uname -srm 2>/dev/null)
+uptime_info=$(uptime -p 2>/dev/null)
+[[ -n "$uptime_info" ]] || uptime_info=$(uptime 2>/dev/null)
+
+if (( $+commands[df] && $+commands[awk] )); then
+    disk_info=$(df -h / 2>/dev/null \
+        | awk 'NR == 2 { printf "%s/%s (%s)", $3, $2, $5; exit }')
+fi
+git_info=$(_motd_git_info)
+
+local -a labels values
+labels=(User Host Zsh OS Kernel Uptime)
+values=(
+    "${USER:-${USERNAME:-unknown}}"
+    "${HOST:-unknown}"
+    "${ZSH_VERSION:-unknown}"
+    "${os_info:-unknown}"
+    "${kernel_info:-unknown}"
+    "${uptime_info:-unknown}"
+)
+
+if [[ -n "$disk_info" ]]; then
+    labels+=(Disk)
+    values+=("$disk_info")
+fi
+if [[ -n "$git_info" ]]; then
+    labels+=(Dotfiles)
+    values+=("$git_info")
+fi
+
+local label_color='' value_color='' reset=''
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    autoload -Uz colors
+    colors
+    label_color="${fg_bold[cyan]}"
+    value_color="${fg_bold[magenta]}"
+    reset="$reset_color"
+fi
+
+local -a spider summary
+spider=(
+    '    |'
+    '  / _ \'
+    '\_\(A)/_/'
+    ' _//o\\_'
+    '  /   \'
+)
+
+integer i row_count=${#labels}
+for (( i = 1; i <= ${#labels}; i++ )); do
+    summary+=("${label_color}${labels[i]}${reset}: ${value_color}${values[i]}${reset}")
+done
+(( ${#spider} > row_count )) && row_count=${#spider}
+
+local art_line summary_line
+for (( i = 1; i <= row_count; i++ )); do
+    art_line="${spider[i]:-}"
+    summary_line="${summary[i]:-}"
+    printf '  %-12s  %s\n' "$art_line" "$summary_line"
+done

--- a/tests/fixtures/motd-command-stub.sh
+++ b/tests/fixtures/motd-command-stub.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+command_name=${0##*/}
+printf '%s %s\n' "$command_name" "$*" >> "${MOTD_COMMAND_LOG:?}"
+
+if [ "$command_name" != git ]; then
+    exit 0
+fi
+
+case "$*" in
+    *"rev-parse --is-inside-work-tree"*)
+        printf 'true\n'
+        ;;
+    *"symbolic-ref --short -q HEAD"*)
+        printf 'feature/test\n'
+        ;;
+    *"rev-parse --abbrev-ref --symbolic-full-name @{upstream}"*)
+        printf 'origin/feature/test\n'
+        ;;
+    *"rev-list --left-right --count HEAD...@{upstream}"*)
+        printf '2\t1\n'
+        ;;
+    *"status --porcelain --untracked-files=normal"*)
+        printf ' M bin/motd\n'
+        ;;
+esac

--- a/tests/test_motd.sh
+++ b/tests/test_motd.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ZSH_BIN="$(command -v zsh || true)"
+if [ -z "$ZSH_BIN" ]; then
+  printf 'SKIP: zsh is not installed\n'
+  exit 0
+fi
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local test_name="$3"
+
+  if [ "$expected" = "$actual" ]; then
+    printf 'PASS: %s\n' "$test_name"
+  else
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' \
+      "$test_name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local value="$1"
+  local pattern="$2"
+  local test_name="$3"
+
+  if grep -Eq -- "$pattern" <<< "$value"; then
+    printf 'PASS: %s\n' "$test_name"
+  else
+    printf 'FAIL: %s\nmissing pattern: %s\nvalue: %s\n' \
+      "$test_name" "$pattern" "$value" >&2
+    exit 1
+  fi
+}
+
+make_stubs() {
+  local destination="$1"
+  shift
+
+  mkdir -p "$destination"
+  local command_name
+  for command_name in "$@"; do
+    ln -s "$REPO_ROOT/tests/fixtures/motd-command-stub.sh" \
+      "$destination/$command_name"
+  done
+}
+
+test_startup_is_opt_in() {
+  local secret_dir output
+  secret_dir="$TEST_DIR/secrets"
+  mkdir -p "$secret_dir"
+
+  output="$(
+    ZDOTDIR="$secret_dir" MOTD_DEINIT="$REPO_ROOT/zsh/99_deinit.zsh" \
+      "$ZSH_BIN" -f -ic \
+      'unset DOTFILES_MOTD_ON_START
+       motd() { print -r -- called; }
+       source "$MOTD_DEINIT"' 2>/dev/null
+  )"
+  assert_eq "" "$output" "interactive startup does not run motd by default"
+
+  output="$(
+    ZDOTDIR="$secret_dir" DOTFILES_MOTD_ON_START=1 \
+      MOTD_DEINIT="$REPO_ROOT/zsh/99_deinit.zsh" \
+      "$ZSH_BIN" -f -ic \
+      'motd() { print -r -- called; }
+       source "$MOTD_DEINIT"' 2>/dev/null
+  )"
+  assert_eq "called" "$output" "interactive startup can opt in to motd"
+}
+
+test_small_terminal_short_circuits() {
+  local fake_bin log output
+  fake_bin="$TEST_DIR/small-bin"
+  log="$TEST_DIR/small-commands.log"
+  : > "$log"
+
+  make_stubs "$fake_bin" \
+    git uname uptime df awk sw_vers free tput hostname whoami stat date \
+    cat grep cut tr wc top lsb_release \
+    brew mise curl wget gh ssh apt apt-get softwareupdate
+
+  output="$(
+    MOTD_COMMAND_LOG="$log" PATH="$fake_bin:$PATH" \
+      LINES=5 COLUMNS=40 "$ZSH_BIN" "$REPO_ROOT/bin/motd"
+  )"
+
+  assert_eq "" "$output" "small terminal produces no output"
+  assert_eq "" "$(cat "$log")" "small terminal collects no system information"
+}
+
+test_summary_is_local_only() {
+  local fake_bin log output forbidden
+  fake_bin="$TEST_DIR/local-bin"
+  log="$TEST_DIR/local-commands.log"
+  mkdir -p "$TEST_DIR/repo/.git"
+  : > "$log"
+
+  make_stubs "$fake_bin" \
+    git brew mise curl wget gh ssh apt apt-get softwareupdate
+
+  output="$(
+    MOTD_COMMAND_LOG="$log" PATH="$fake_bin:$PATH" \
+      DOTPATH="$TEST_DIR/repo" LINES=24 COLUMNS=100 \
+      "$ZSH_BIN" "$REPO_ROOT/bin/motd"
+  )"
+
+  assert_contains "$output" 'Dotfiles: feature/test, dirty, ahead 2, behind 1' \
+    "summary uses the configured branch and its upstream"
+  assert_contains "$(cat "$log")" '^git .* status --porcelain' \
+    "summary inspects local git status"
+
+  forbidden='^(brew|mise|curl|wget|gh|ssh|apt|apt-get|softwareupdate) |^git .* (fetch|pull|push|clone|ls-remote)( |$)'
+  if grep -Eq -- "$forbidden" "$log"; then
+    printf 'FAIL: summary invoked a network or update command\n' >&2
+    cat "$log" >&2
+    exit 1
+  fi
+  printf 'PASS: summary invokes no network or update commands\n'
+}
+
+test_startup_is_opt_in
+test_small_terminal_short_circuits
+test_summary_is_local_only

--- a/zsh/99_deinit.zsh
+++ b/zsh/99_deinit.zsh
@@ -13,9 +13,9 @@
     done
 }
 
-#
-# Display a spider ASCII art on exit, if the terminal is large enough.
-#
-if [[ -o interactive ]]; then
+# The local system summary is disabled by default. Run `motd` explicitly, or
+# opt in to displaying it during interactive startup.
+if [[ -o interactive && "${DOTFILES_MOTD_ON_START:-0}" == 1 ]] \
+    && (( $+commands[motd] || $+functions[motd] )); then
     motd
 fi


### PR DESCRIPTION
## Summary

- Stop running `motd` during every interactive shell startup by default; keep manual execution and add the explicit `DOTFILES_MOTD_ON_START=1` opt-in.
- Replace the 366-line renderer with a 133-line local-only summary and compact spider.
- Remove update and network activity (`git fetch`, `brew outdated`, `mise outdated`, and `mise version`) from MOTD.
- Derive Git status from the current branch and its configured upstream instead of hard-coding `master`.
- Check terminal dimensions before collecting any system or repository information.
- Add regression tests for startup opt-in, small-terminal short-circuiting, local Git status, and absence of network/update commands.

## Why

The MOTD mixed presentation, shell-startup behavior, update checking, and repository mutation. Because it was invoked for every interactive shell, those responsibilities added startup latency and could cause background network activity without an explicit user action. It also depended on helper functions unavailable to the standalone script and assumed the repository used `master`.

## Impact

Interactive shells no longer display MOTD unless explicitly opted in. The `motd` command remains available and reports user, host, Zsh, OS, kernel, uptime, disk usage, and local dotfiles branch status. It never refreshes remote state, so ahead/behind counts are based on existing local refs.

## Validation

- `./tests/test_motd.sh`
- `./tests/test_shell_startup.sh`
- `./tests/test_update_script.sh`
- `zsh -n bin/motd zsh/*.zsh`
- `bash -n tests/*.sh`
- `sh -n tests/fixtures/motd-command-stub.sh`
- `git diff --check`