### PR TITLE
Harden Zsh startup and history handling

### DIFF
--- a/shell/env.sh
+++ b/shell/env.sh
@@ -26,10 +26,9 @@ export GIT_EDITOR="$EDITOR"
 export PAGER="${PAGER:-less}"
 
 # Locale
-export LANGUAGE="${LANGUAGE:-en_US.UTF-8}"
-export LANG="$LANGUAGE"
-export LC_ALL="$LANGUAGE"
-export LC_CTYPE="$LANGUAGE"
+: "${LANG:=en_US.UTF-8}"
+: "${LANGUAGE:=$LANG}"
+export LANG LANGUAGE
 
 # Less configuration
 export LESS='-R -f -X -i -P ?f%f:(stdin). ?lb%lb?L/%L.. [?eEOF:?pb%pb\%..]'

--- a/tests/test_shell_startup.sh
+++ b/tests/test_shell_startup.sh
@@ -18,26 +18,121 @@ assert_eq() {
   fi
 }
 
-test_zsh_dotpath_from_symlink() {
+test_zsh_noninteractive_startup() {
   if ! command -v zsh >/dev/null 2>&1; then
     printf 'SKIP: zsh is not installed\n'
     return
   fi
 
-  local home output dotpath runtime_dir
-  home="$TEST_DIR/zsh-home"
+  local home output dotpath zdotdir histfile global_rcs
+  home="$TEST_DIR/zsh-noninteractive-home"
   mkdir -p "$home"
   ln -s "$REPO_ROOT/zsh/.zshenv" "$home/.zshenv"
 
   output="$(
-    env -u DOTPATH -u ZDOTDIR -u XDG_RUNTIME_DIR HOME="$home" zsh -c \
-      'printf "%s\n%s\n" "$DOTPATH" "$XDG_RUNTIME_DIR"; test -d "$XDG_RUNTIME_DIR"'
+    env \
+      -u DOTPATH \
+      -u HISTFILE \
+      -u XDG_CACHE_HOME \
+      -u XDG_CONFIG_HOME \
+      -u XDG_DATA_HOME \
+      -u XDG_RUNTIME_DIR \
+      -u XDG_STATE_HOME \
+      -u ZDOTDIR \
+      HOME="$home" \
+      zsh -c 'printf "%s\n%s\n%s\n%s\n" "$DOTPATH" "$ZDOTDIR" "${HISTFILE-unset}" "$options[globalrcs]"'
   )"
   dotpath="$(printf '%s\n' "$output" | sed -n '1p')"
-  runtime_dir="$(printf '%s\n' "$output" | sed -n '2p')"
+  zdotdir="$(printf '%s\n' "$output" | sed -n '2p')"
+  histfile="$(printf '%s\n' "$output" | sed -n '3p')"
+  global_rcs="$(printf '%s\n' "$output" | sed -n '4p')"
 
-  assert_eq "$REPO_ROOT" "$dotpath" "zsh resolves DOTPATH from .zshenv symlink"
-  assert_eq "$home/.temp" "$runtime_dir" "zsh creates default XDG_RUNTIME_DIR"
+  assert_eq "$REPO_ROOT" "$dotpath" "noninteractive zsh resolves DOTPATH from .zshenv symlink"
+  assert_eq "$home/.config/zsh" "$zdotdir" "noninteractive zsh selects the XDG startup directory"
+  assert_eq "unset" "$histfile" "noninteractive zsh does not configure interactive history"
+  assert_eq "on" "$global_rcs" "zsh keeps global startup files enabled"
+  assert_eq "absent" "$([ -e "$home/.local" ] && printf 'present' || printf 'absent')" \
+    "noninteractive zsh does not create state directories"
+}
+
+test_zsh_interactive_startup() {
+  if ! command -v zsh >/dev/null 2>&1; then
+    return
+  fi
+
+  local home output histfile lang lc_all append_history share_history
+  home="$TEST_DIR/zsh-interactive-home"
+  mkdir -p "$home/.config/zsh"
+  ln -s "$REPO_ROOT/zsh/.zshenv" "$home/.zshenv"
+  ln -s "$REPO_ROOT/zsh/.zshrc" "$home/.config/zsh/.zshrc"
+
+  output="$(
+    env \
+      -u DOTPATH \
+      -u HISTFILE \
+      -u LANG \
+      -u LANGUAGE \
+      -u LC_ALL \
+      -u XDG_CACHE_HOME \
+      -u XDG_CONFIG_HOME \
+      -u XDG_DATA_HOME \
+      -u XDG_RUNTIME_DIR \
+      -u XDG_STATE_HOME \
+      -u ZDOTDIR \
+      HOME="$home" \
+      PATH="/usr/bin:/bin" \
+      zsh -ic \
+      'printf "__HISTFILE__%s\n__LANG__%s\n__LC_ALL__%s\n__APPEND__%s\n__SHARE__%s\n" \
+        "$HISTFILE" "$LANG" "${LC_ALL-unset}" "$options[appendhistory]" "$options[sharehistory]"' \
+      2>/dev/null
+  )"
+  histfile="$(printf '%s\n' "$output" | sed -n 's/^__HISTFILE__//p')"
+  lang="$(printf '%s\n' "$output" | sed -n 's/^__LANG__//p')"
+  lc_all="$(printf '%s\n' "$output" | sed -n 's/^__LC_ALL__//p')"
+  append_history="$(printf '%s\n' "$output" | sed -n 's/^__APPEND__//p')"
+  share_history="$(printf '%s\n' "$output" | sed -n 's/^__SHARE__//p')"
+
+  assert_eq "$home/.local/state/zsh/history" "$histfile" "interactive zsh stores history under XDG state"
+  assert_eq "en_US.UTF-8" "$lang" "interactive zsh supplies a LANG default"
+  assert_eq "unset" "$lc_all" "interactive zsh does not force LC_ALL"
+  assert_eq "on" "$append_history" "interactive zsh appends history across sessions"
+  assert_eq "on" "$share_history" "interactive zsh shares history across sessions"
+  assert_eq "present" "$([ -d "$home/.local/state/zsh" ] && printf 'present' || printf 'absent')" \
+    "interactive zsh creates its history directory"
+  assert_eq "present" "$([ -d "$home/.cache/zsh" ] && printf 'present' || printf 'absent')" \
+    "interactive zsh creates its cache directory"
+}
+
+test_zsh_preserves_locale_overrides() {
+  if ! command -v zsh >/dev/null 2>&1; then
+    return
+  fi
+
+  local home output
+  home="$TEST_DIR/zsh-locale-home"
+  mkdir -p "$home/.config/zsh"
+  ln -s "$REPO_ROOT/zsh/.zshenv" "$home/.zshenv"
+  ln -s "$REPO_ROOT/zsh/.zshrc" "$home/.config/zsh/.zshrc"
+
+  output="$(
+    env \
+      -u DOTPATH \
+      -u LANGUAGE \
+      -u XDG_CACHE_HOME \
+      -u XDG_CONFIG_HOME \
+      -u XDG_DATA_HOME \
+      -u XDG_RUNTIME_DIR \
+      -u XDG_STATE_HOME \
+      -u ZDOTDIR \
+      HOME="$home" \
+      LANG=C \
+      LC_ALL=C \
+      PATH="/usr/bin:/bin" \
+      zsh -ic 'printf "%s\n%s\n" "$LANG" "$LC_ALL"' \
+      2>/dev/null
+  )"
+
+  assert_eq "C"$'\n'"C" "$output" "interactive zsh preserves caller locale overrides"
 }
 
 test_bash_dotpath_from_symlink() {
@@ -58,5 +153,7 @@ test_bash_dotpath_from_symlink() {
   assert_eq "$home/.temp" "$runtime_dir" "bash creates default XDG_RUNTIME_DIR"
 }
 
-test_zsh_dotpath_from_symlink
+test_zsh_noninteractive_startup
+test_zsh_interactive_startup
+test_zsh_preserves_locale_overrides
 test_bash_dotpath_from_symlink

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,58 +1,18 @@
 #
-# Defines environment variables for Zsh.
+# Defines the minimal environment required before Zsh selects its startup files.
 #
 
-# Avoid sourcing /etc/zshenv when possible.
-setopt no_global_rcs
-
-# Ensure DOTPATH is available before loading shared configuration.
+# Resolve the repository from this file's installed symlink when possible.
 if [[ -z ${DOTPATH:-} ]]; then
-    _dotfiles_zshenv_file="${ZDOTDIR:-$HOME}/.zshenv"
-    if [[ -L "${_dotfiles_zshenv_file}" ]] && command -v readlink >/dev/null 2>&1; then
-        _dotfiles_zshenv_target="$(readlink "${_dotfiles_zshenv_file}")"
-        if [[ "${_dotfiles_zshenv_target}" == /* ]]; then
-            _dotfiles_zshenv_file="${_dotfiles_zshenv_target}"
-        else
-            _dotfiles_zshenv_file="${_dotfiles_zshenv_file:h}/${_dotfiles_zshenv_target}"
-        fi
-    fi
-    _dotfiles_zshenv_dir="$(cd "${_dotfiles_zshenv_file:h}" 2>/dev/null && pwd -P)"
-    if [[ -n "${_dotfiles_zshenv_dir}" ]]; then
-        _dotfiles_zshenv_file="${_dotfiles_zshenv_dir}/${_dotfiles_zshenv_file:t}"
-    fi
-    _dotfiles_candidate="${_dotfiles_zshenv_file:h:h}"
+    _dotfiles_candidate="${${(%):-%N}:A:h:h}"
     if [[ -r "${_dotfiles_candidate}/shell/env.sh" ]]; then
         export DOTPATH="${_dotfiles_candidate}"
     else
         export DOTPATH=${HOME}/.dotfiles
     fi
-    unset _dotfiles_zshenv_file _dotfiles_zshenv_target _dotfiles_zshenv_dir _dotfiles_candidate
+    unset _dotfiles_candidate
 fi
 
-# Load shared, POSIX-compatible environment configuration.
-if [[ -r "${DOTPATH}/shell/env.sh" ]]; then
-    source "${DOTPATH}/shell/env.sh"
-fi
-
-# Zsh-specific directories and history configuration.
+: "${XDG_CONFIG_HOME:=${HOME}/.config}"
+export XDG_CONFIG_HOME
 export ZDOTDIR=${XDG_CONFIG_HOME}/zsh
-export HISTFILE=${XDG_STATE_HOME}/zsh/history
-export HISTSIZE=10000
-export SAVEHIST=1000000
-export LISTMAX=50
-
-if [[ ${UID} -eq 0 ]]; then
-    unset HISTFILE
-    export SAVEHIST=0
-fi
-
-# Spell correction configuration.
-export CORRECT_IGNORE='_*'
-export CORRECT_IGNORE_FILE='.*'
-
-# Word characters used when moving across words.
-export WORDCHARS='*?_-.[]~=&;!#$%^(){}<>'
-
-# Ensure PATH stays unique when converted to the Zsh array form.
-typeset -gU path
-path=(${(s/:/)PATH})

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -8,6 +8,44 @@ umask 022
 # no dump core file
 limit coredumpsize 0
 
+# Load the shared environment only for interactive Zsh sessions.
+if [[ -r "${DOTPATH}/shell/env.sh" ]]; then
+    source "${DOTPATH}/shell/env.sh"
+fi
+
+# Keep Zsh state out of the configuration directory on fresh installations.
+_dotfiles_zsh_state_dir="${XDG_STATE_HOME}/zsh"
+_dotfiles_zsh_cache_dir="${XDG_CACHE_HOME}/zsh"
+mkdir -p "${_dotfiles_zsh_state_dir}" "${_dotfiles_zsh_cache_dir}"
+chmod 700 "${_dotfiles_zsh_state_dir}" 2>/dev/null || true
+
+export HISTFILE="${_dotfiles_zsh_state_dir}/history"
+export HISTSIZE=10000
+export SAVEHIST=1000000
+export LISTMAX=50
+
+if [[ ${UID} -eq 0 ]]; then
+    unset HISTFILE
+    export SAVEHIST=0
+else
+    # Append commands incrementally and import commands from concurrent shells.
+    setopt append_history
+    setopt share_history
+fi
+
+unset _dotfiles_zsh_state_dir _dotfiles_zsh_cache_dir
+
+# Spell correction configuration.
+export CORRECT_IGNORE='_*'
+export CORRECT_IGNORE_FILE='.*'
+
+# Word characters used when moving across words.
+export WORDCHARS='*?_-.[]~=&;!#$%^(){}<>'
+
+# Ensure PATH stays unique when converted to the Zsh array form.
+typeset -gU path
+path=(${(s/:/)PATH})
+
 # Return if zsh is called from Vim
 if [[ -n ${VIMRUNTIME} ]]; then
     return 0


### PR DESCRIPTION
## Summary

- reduce `.zshenv` to repository discovery plus `XDG_CONFIG_HOME`/`ZDOTDIR` selection
- move shared environment and interactive Zsh settings into `.zshrc`
- create XDG state/cache directories before history and completion use
- append and share history safely across concurrent interactive sessions
- preserve caller locale overrides, provide a `LANG` default, and stop forcing `LC_ALL`/`LC_CTYPE`
- expand isolated startup coverage while retaining the existing Bash startup check

## Root cause

Every Zsh invocation sourced the full shared environment, created directories, and disabled later global startup files even though `/etc/zshenv` had already run. Fresh interactive sessions also pointed `HISTFILE` at a directory that was not guaranteed to exist and lacked append/share options, allowing concurrent sessions to overwrite or miss history.

## Impact

Noninteractive Zsh startup now stays side-effect free beyond selecting its startup directory. Interactive shells initialize their state reliably, retain commands from concurrent sessions, and respect locale values supplied by the caller. Bash startup behavior remains covered and unchanged apart from the intentional shared locale semantics.

## Validation

- `bash tests/test_shell_startup.sh`
- `bash tests/test_update_script.sh`
- `bash -n shell/env.sh tests/test_shell_startup.sh`
- `zsh -n zsh/.zshenv zsh/.zshrc zsh/00_init.zsh zsh/10_util.zsh zsh/20_keybinds.zsh zsh/30_aliases.zsh zsh/50_setopt.zsh zsh/70_misc.zsh zsh/80_custom.zsh zsh/99_deinit.zsh`
- `git diff --check`