### PR TITLE
Bash 起動時の Sheldon 依存を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,15 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/master/install.sh 
 | `cat` | `bat` | Display file content with bat |
 
 ## Bash設定
-- `~/.config/bash/[0-9][0-9]_*.bash` を `plugins.bash.toml` で定義した `sheldon` プロファイルから読み込む。
+- `.bashrc` から `bash/20_aliases.bash` を直接読み込む。単一ファイルの読み込みにプラグインマネージャーは使用しない。
 - `shell/env.sh` に共通の環境変数をまとめており、Zsh/Bash 双方で共有。
 - 共通エイリアスは `shell/aliases.sh` に定義している。
 
-### Sheldon profiles
+### Sheldon profile
 
 | Shell | Config | Loaded items |
 | :--- | :--- | :--- |
 | Zsh | `sheldon/plugins.toml` | `pure`, `zsh-completions`, `zsh-defer`, `zsh-autosuggestions`, `zsh-syntax-highlighting`, `~/.config/zsh/[0-9][0-9]_*.zsh` |
-| Bash | `sheldon/plugins.bash.toml` | `~/.config/bash/[0-9][0-9]_*.bash` |
 
 ## Mise設定
 

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -53,14 +53,11 @@ if command -v mise >/dev/null 2>&1; then
   eval "$(mise activate bash)"
 fi
 
-###########
-# sheldon #
-###########
-if command -v sheldon >/dev/null 2>&1; then
-  eval "$( \
-    SHELDON_CONFIG_FILE="${XDG_CONFIG_HOME}/sheldon/plugins.bash.toml" \
-    sheldon source
-  )"
+###################
+# shared aliases  #
+###################
+if [ -r "$DOTPATH/bash/20_aliases.bash" ]; then
+  . "$DOTPATH/bash/20_aliases.bash"
 fi
 
 # Load local settings if present.

--- a/sheldon/plugins.bash.toml
+++ b/sheldon/plugins.bash.toml
@@ -1,5 +1,0 @@
-shell = 'bash'
-
-[plugins.custom]
-local = '~/.config/bash'
-use = ['[0-9][0-9]_*.bash']

--- a/tests/test_shell_startup.sh
+++ b/tests/test_shell_startup.sh
@@ -153,7 +153,35 @@ test_bash_dotpath_from_symlink() {
   assert_eq "$home/.temp" "$runtime_dir" "bash creates default XDG_RUNTIME_DIR"
 }
 
+test_bash_loads_aliases_without_sheldon() {
+  local home fake_bin sheldon_log output
+  home="$TEST_DIR/bash-alias-home"
+  fake_bin="$TEST_DIR/fake-bin"
+  sheldon_log="$TEST_DIR/sheldon.log"
+  mkdir -p "$home" "$fake_bin"
+  ln -s "$REPO_ROOT/bash/.bashrc" "$home/.bashrc"
+
+  cat >"$fake_bin/sheldon" <<EOF
+#!/usr/bin/env bash
+printf 'invoked\n' >>"$sheldon_log"
+EOF
+  chmod +x "$fake_bin/sheldon"
+
+  output="$(
+    env -u DOTPATH HOME="$home" PATH="$fake_bin:$PATH" bash -ic \
+      'alias ll' 2>/dev/null
+  )"
+
+  assert_eq "alias ll='eza -lF'" "$output" "bash loads shared aliases directly"
+  if [ -e "$sheldon_log" ]; then
+    printf 'FAIL: bash invoked Sheldon for a static alias file\n' >&2
+    exit 1
+  fi
+  printf 'PASS: bash does not invoke Sheldon\n'
+}
+
 test_zsh_noninteractive_startup
 test_zsh_interactive_startup
 test_zsh_preserves_locale_overrides
 test_bash_dotpath_from_symlink
+test_bash_loads_aliases_without_sheldon


### PR DESCRIPTION
## What

- Bash の静的なエイリアスファイルを `.bashrc` から直接読み込む
- Bash 専用 Sheldon プロファイルを削除
- Sheldon が存在しても Bash 起動時に呼ばれないことをテスト
- README の構成説明を同期

## Why

Bash 側で Sheldon が担っていたのは単一のローカルファイルの読み込みだけでした。シェル起動ごとに外部プロセスを起動して設定を生成する構成は、得られる機能に対して複雑さと起動コストが大きいためです。Zsh のプラグイン管理には引き続き Sheldon を使用します。

## Impact

Bash の共通エイリアスは従来どおり利用できます。追加の Bash プラグインを `plugins.bash.toml` に登録していた利用者は、`.bashrc.local` から明示的に読み込む必要があります。

## Dependency

起動テストの同一箇所を変更するため、競合を事前解消して #14 (`agent/reliable-zsh-startup`) の上にstackしています。#14 のマージ後にbaseを `master` へ変更できます。

## Checks

- `./tests/test_shell_startup.sh`（Zsh/Bash双方）
- `./tests/test_update_script.sh`
- Bash / Zsh 構文検査
- ShellCheck 0.11.0（変更対象）
- `git diff --check`