### PR TITLE
Harden install and uninstall lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/master/install.sh 
 
 3.  シンボリックリンクの作成:
     *   .dotfiles内の設定ファイルやディレクトリへのシンボリックリンクを `$XDG_CONFIG_HOME` や `$HOME` 配下に作成する。
-    *   既存のファイルやディレクトリがある場合、それらは `$XDG_DATA_HOME/dotfiles/backup_YYYYMMDDHHMMSS/` 以下にバックアップする。
+    *   既存のファイルやディレクトリがある場合、それらは `$XDG_DATA_HOME/dotfiles/backup_*/` 以下にバックアップする。
+    *   作成したリンクとバックアップの対応は `$XDG_STATE_HOME/dotfiles/install-state.tsv` に記録する。再実行時、既に正しいリンクは変更しない。
 
 4.  追加ツールのインストール:
     *   `mise` と `sheldon` が未導入の場合はインストールする。
@@ -55,7 +56,9 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/master/install.sh 
 #### `DOTPATH`
 
 .dotfilesリポジトリをクローンする場所を指定する。
-デフォルトでは、`install.sh` があるディレクトリの `.dotfiles` サブディレクトリ (`$PWD/.dotfiles`) となる。
+ローカルのGit checkoutから実行した場合はそのcheckoutを使用する。単独で取得した
+`install.sh` から実行した場合は、スクリプトがあるディレクトリの `.dotfiles`
+サブディレクトリとなる。
 
 > 例: ~/src/github.com/akgm3i/.dotfiles にインストールする場合
 > ```bash
@@ -69,6 +72,9 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/master/install.sh 
 ```
 
 `install.sh` を実行した際のバックアップを復元する。
+インストール状態に記録され、リンク先が記録内容と一致するリンクだけを削除する。
+インストール後に差し替えられたリンクや、元から存在したリンクは削除しない。
+`mise` と Sheldon のバイナリおよび管理データは共有インストールとして残す。
 
 ## Zsh設定
 ### Plugins

--- a/install.sh
+++ b/install.sh
@@ -22,42 +22,54 @@ setup_dotpath() {
     fi
 
     # Executed from a local file.
-    local script_dir
-    script_dir="$(cd "$(dirname "$0")" && pwd)"
-    local git_config_path="$script_dir/.git/config"
+    local script_path="${1:-${BASH_SOURCE[0]:-$0}}"
+    local script_dir git_root
+    script_dir="$(cd "$(dirname "$script_path")" && pwd -P)"
 
-    if [ -f "$git_config_path" ] && grep -q "url = ${DOTFILES_REPO}" "$git_config_path"; then
-        # Executed from a local git directory.
+    if git_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null)" \
+        && [ "$(cd "$git_root" && pwd -P)" = "$script_dir" ] \
+        && git -C "$script_dir" ls-files --error-unmatch -- "$(basename "$script_path")" >/dev/null 2>&1; then
+        # Executed from the root of a local checkout. The remote URL is
+        # intentionally irrelevant so SSH remotes and forks work as expected.
         DOTPATH="$script_dir"
     else
         # Executed from a standalone script.
         DOTPATH="$script_dir/.dotfiles"
     fi
 }
-setup_dotpath
-unset -f setup_dotpath
+setup_dotpath "${BASH_SOURCE[0]:-$0}"
 
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-"$HOME/.config"}
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-"$HOME/.cache"}
 XDG_DATA_HOME=${XDG_DATA_HOME:-"$HOME/.local/share"}
 XDG_STATE_HOME=${XDG_STATE_HOME:-"$HOME/.local/state"}
 XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-"$HOME/.temp"}
+DOTFILES_STATE_DIR=${DOTFILES_STATE_DIR:-"$XDG_STATE_HOME/dotfiles"}
+DOTFILES_INSTALL_STATE=${DOTFILES_INSTALL_STATE:-"$DOTFILES_STATE_DIR/install-state.tsv"}
 
 # --- Globals ---
 backup_dir=""
+backup_sequence=0
+state_tmp=""
 
 # --- Cleanup function for trap ---
 cleanup() {
-    if [ "$?" != "0" ]; then
+    local exit_status=$?
+
+    if [ -n "$state_tmp" ] && [ -e "$state_tmp" ]; then
+        rm -f "$state_tmp"
+    fi
+
+    if [ "$exit_status" != "0" ]; then
         log_error "Installation failed."
         if [ -n "$backup_dir" ]; then
             log_info "Your original files were backed up to: $backup_dir"
             log_info "You can restore them manually."
         fi
     fi
-}
 
-trap cleanup EXIT
+    return "$exit_status"
+}
 
 # --- Check if a command exists ---
 has() {
@@ -137,13 +149,142 @@ check_dependencies() {
     fi
 }
 
+canonical_path() {
+    local path=$1
+    local dir base
+
+    if [ -d "$path" ]; then
+        (cd "$path" 2>/dev/null && pwd -P)
+        return
+    fi
+
+    dir="$(dirname "$path")"
+    base="$(basename "$path")"
+    (cd "$dir" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$base")
+}
+
+symlink_points_to() {
+    local link=$1
+    local expected=$2
+    local target
+
+    [ -L "$link" ] || return 1
+    target="$(readlink "$link")"
+    case "$target" in
+        /*) ;;
+        *) target="$(dirname "$link")/$target" ;;
+    esac
+
+    [ "$(canonical_path "$target")" = "$(canonical_path "$expected")" ]
+}
+
+managed_symlink_matches() {
+    local link=$1
+    local recorded_source=$2
+
+    [ -L "$link" ] && [ "$(readlink "$link")" = "$recorded_source" ]
+}
+
+state_status=""
+state_source=""
+state_backup=""
+
+load_state_record() {
+    local destination=$1
+    local record_status record_source record_destination record_backup
+
+    state_status=""
+    state_source=""
+    state_backup=""
+    [ -r "$DOTFILES_INSTALL_STATE" ] || return 1
+
+    while IFS=$'\t' read -r record_status record_source record_destination record_backup; do
+        case "$record_status" in
+            created|preexisting)
+                if [ "$record_destination" = "$destination" ]; then
+                    state_status="$record_status"
+                    state_source="$record_source"
+                    state_backup="$record_backup"
+                    return 0
+                fi
+                ;;
+        esac
+    done < "$DOTFILES_INSTALL_STATE"
+
+    return 1
+}
+
+append_state_record() {
+    local status=$1
+    local source=$2
+    local destination=$3
+    local backup=$4
+
+    printf '%s\t%s\t%s\t%s\n' "$status" "$source" "$destination" "$backup" >> "$state_tmp"
+}
+
+state_has_destination() {
+    local state_file=$1
+    local destination=$2
+    local record_status record_source record_destination record_backup
+
+    while IFS=$'\t' read -r record_status record_source record_destination record_backup; do
+        case "$record_status" in
+            created|preexisting)
+                [ "$record_destination" = "$destination" ] && return 0
+                ;;
+        esac
+    done < "$state_file"
+
+    return 1
+}
+
+create_backup_dir() {
+    local backup_parent="$XDG_DATA_HOME/dotfiles"
+
+    [ -n "$backup_dir" ] && return
+    mkdir -p "$backup_parent"
+    backup_dir="$(mktemp -d "$backup_parent/backup_$(date +%Y%m%d%H%M%S)_XXXXXX")"
+    mkdir -p "$backup_dir/items"
+    log_info "Created backup directory: $backup_dir"
+}
+
+backed_up_path=""
+
+backup_destination() {
+    local destination=$1
+
+    create_backup_dir
+    while :; do
+        backup_sequence=$((backup_sequence + 1))
+        backed_up_path="$backup_dir/items/item_$backup_sequence"
+        if [ ! -e "$backed_up_path" ] && [ ! -L "$backed_up_path" ]; then
+            break
+        fi
+    done
+
+    log_info "Backing up existing file: $destination"
+    if ! mv "$destination" "$backed_up_path"; then
+        log_error "Failed to back up $destination. Aborting."
+        exit 1
+    fi
+}
 
 create_symlinks() {
     log_info "Creating symbolic links..."
 
     # Ensure target directories exist
-    mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR"
+    mkdir -p \
+        "$XDG_CONFIG_HOME" \
+        "$XDG_CACHE_HOME" \
+        "$XDG_DATA_HOME" \
+        "$XDG_STATE_HOME" \
+        "$XDG_RUNTIME_DIR" \
+        "$DOTFILES_STATE_DIR"
     chmod 700 "$XDG_RUNTIME_DIR" 2>/dev/null || true
+    state_tmp="$(mktemp "$DOTFILES_STATE_DIR/.install-state.XXXXXX")"
+    chmod 600 "$state_tmp"
+    printf 'version\t1\n' > "$state_tmp"
 
     local symlinks=(
         "$DOTPATH/git:$XDG_CONFIG_HOME/git"
@@ -167,30 +308,76 @@ create_symlinks() {
     for link in "${symlinks[@]}"; do
         local src="${link%%:*}"
         local dest="${link#*:}"
-
-        if [ -e "$dest" ] || [ -L "$dest" ]; then
-            if [ -z "$backup_dir" ]; then
-                backup_dir="$XDG_DATA_HOME/dotfiles/backup_$(date +%Y%m%d%H%M%S)"
-                mkdir -p "$backup_dir"
-                log_info "Created backup directory: $backup_dir"
-            fi
-            log_info "Backing up existing file: $dest"
-            # Preserve directory structure in backup
-            local backup_path="$backup_dir/$(dirname "${dest#$HOME/}")"
-            mkdir -p "$backup_path"
-            if ! mv "$dest" "$backup_path/"; then
-                log_error "Failed to back up $dest. Aborting."
-                exit 1
-            fi
-        fi
+        local previous_state=false
+        local record_status="created"
+        local record_backup="-"
 
         if [ ! -e "$src" ]; then
             log_error "Source file not found: $src"
             exit 1
         fi
-        ln -snf "$src" "$dest"
+
+        if load_state_record "$dest"; then
+            previous_state=true
+        fi
+
+        if symlink_points_to "$dest" "$src"; then
+            if [ "$previous_state" = true ] \
+                && [ "$state_status" = "created" ] \
+                && managed_symlink_matches "$dest" "$state_source"; then
+                record_status="created"
+                record_backup="$state_backup"
+            else
+                # Do not claim ownership of a link that predates this install or
+                # was changed outside the installer.
+                record_status="preexisting"
+            fi
+            append_state_record "$record_status" "$src" "$dest" "$record_backup"
+            log_info "Already linked $src -> $dest"
+            continue
+        fi
+
+        if [ -e "$dest" ] || [ -L "$dest" ]; then
+            if [ "$previous_state" = true ] \
+                && [ "$state_status" = "created" ] \
+                && managed_symlink_matches "$dest" "$state_source"; then
+                if [ "$state_backup" != "-" ] \
+                    && [ ! -e "$state_backup" ] \
+                    && [ ! -L "$state_backup" ]; then
+                    log_error "Recorded backup is missing for $dest: $state_backup"
+                    exit 1
+                fi
+                rm "$dest"
+                record_backup="$state_backup"
+            else
+                backup_destination "$dest"
+                record_backup="$backed_up_path"
+            fi
+        elif [ "$previous_state" = true ] && [ "$state_status" = "created" ]; then
+            record_backup="$state_backup"
+        fi
+
+        ln -s "$src" "$dest"
+        append_state_record "created" "$src" "$dest" "$record_backup"
         log_info "Linked $src -> $dest"
     done
+
+    # Keep records for platform-specific links that are not part of this run.
+    if [ -r "$DOTFILES_INSTALL_STATE" ]; then
+        local old_status old_source old_destination old_backup
+        while IFS=$'\t' read -r old_status old_source old_destination old_backup; do
+            case "$old_status" in
+                created|preexisting)
+                    if ! state_has_destination "$state_tmp" "$old_destination"; then
+                        append_state_record "$old_status" "$old_source" "$old_destination" "$old_backup"
+                    fi
+                    ;;
+            esac
+        done < "$DOTFILES_INSTALL_STATE"
+    fi
+
+    mv "$state_tmp" "$DOTFILES_INSTALL_STATE"
+    state_tmp=""
 }
 
 install_tools() {
@@ -247,6 +434,8 @@ switch_shell_to_zsh() {
 }
 
 main() {
+    trap cleanup EXIT
+
     check_dependencies
     clone_or_update_repo
     create_symlinks
@@ -267,4 +456,6 @@ main() {
     fi
 }
 
-main
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    main "$@"
+fi

--- a/tests/test_install_lifecycle.sh
+++ b/tests/test_install_lifecycle.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-TEST_DIR="$(mktemp -d)"
+TEST_DIR="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TEST_DIR"' EXIT
 
 assert_eq() {

--- a/tests/test_install_lifecycle.sh
+++ b/tests/test_install_lifecycle.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+assert_eq() {
+    local expected=$1
+    local actual=$2
+    local test_name=$3
+
+    if [ "$expected" = "$actual" ]; then
+        printf 'PASS: %s\n' "$test_name"
+        return
+    fi
+
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' \
+        "$test_name" "$expected" "$actual" >&2
+    exit 1
+}
+
+assert_exists() {
+    local path=$1
+    local test_name=$2
+
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        printf 'PASS: %s\n' "$test_name"
+        return
+    fi
+
+    printf 'FAIL: %s\nmissing: %s\n' "$test_name" "$path" >&2
+    exit 1
+}
+
+assert_not_exists() {
+    local path=$1
+    local test_name=$2
+
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        printf 'PASS: %s\n' "$test_name"
+        return
+    fi
+
+    printf 'FAIL: %s\nunexpected path: %s\n' "$test_name" "$path" >&2
+    exit 1
+}
+
+prepare_home() {
+    local name=$1
+
+    HOME="$TEST_DIR/$name"
+    XDG_CONFIG_HOME="$HOME/.config"
+    XDG_CACHE_HOME="$HOME/.cache"
+    XDG_DATA_HOME="$HOME/.local/share"
+    XDG_STATE_HOME="$HOME/.local/state"
+    XDG_RUNTIME_DIR="$HOME/.temp"
+    DOTPATH="$REPO_ROOT"
+    DOTFILES_STATE_DIR="$XDG_STATE_HOME/dotfiles"
+    DOTFILES_INSTALL_STATE="$DOTFILES_STATE_DIR/install-state.tsv"
+    export HOME XDG_CONFIG_HOME XDG_CACHE_HOME XDG_DATA_HOME XDG_STATE_HOME
+    export XDG_RUNTIME_DIR DOTPATH DOTFILES_STATE_DIR DOTFILES_INSTALL_STATE
+    mkdir -p "$HOME"
+}
+
+state_backup_for() {
+    local destination=$1
+
+    awk -F '\t' -v destination="$destination" \
+        '$1 == "created" && $3 == destination { print $4 }' \
+        "$DOTFILES_INSTALL_STATE"
+}
+
+backup_count() {
+    local count=0
+    local path
+
+    for path in "$XDG_DATA_HOME/dotfiles"/backup_*; do
+        [ -d "$path" ] || continue
+        count=$((count + 1))
+    done
+    printf '%s\n' "$count"
+}
+
+test_local_checkout_detection_ignores_remote_url() (
+    local checkout="$TEST_DIR/fork-checkout"
+    local home="$TEST_DIR/detection-home"
+    local detected
+
+    mkdir -p "$checkout" "$home"
+    cp "$REPO_ROOT/install.sh" "$checkout/install.sh"
+    git -C "$checkout" init -q
+    git -C "$checkout" add install.sh
+    git -C "$checkout" remote add origin git@github.com:someone/dotfiles-fork.git
+
+    detected="$(
+        env -u DOTPATH HOME="$home" bash -c \
+            'source "$1"; printf "%s\n" "$DOTPATH"' \
+            _ "$checkout/install.sh"
+    )"
+
+    assert_eq "$checkout" "$detected" \
+        "local checkout is detected with an SSH fork remote"
+)
+
+test_install_repeat_and_restore() (
+    prepare_home "lifecycle-home"
+    printf 'original bashrc\n' > "$HOME/.bashrc"
+
+    # Sourcing exposes the lifecycle functions without invoking network,
+    # package-manager, sudo, or chsh operations.
+    # shellcheck source=../install.sh
+    source "$REPO_ROOT/install.sh"
+    create_symlinks
+
+    assert_eq "$REPO_ROOT/git" "$(readlink "$XDG_CONFIG_HOME/git")" \
+        "first install links config directory"
+    assert_eq "$REPO_ROOT/zsh/.zshenv" "$(readlink "$HOME/.zshenv")" \
+        "first install links home file"
+
+    local original_backup first_backup_count second_backup_count
+    original_backup="$(state_backup_for "$HOME/.bashrc")"
+    assert_exists "$original_backup" "original file is preserved in recorded backup"
+    assert_eq "original bashrc" "$(sed -n '1p' "$original_backup")" \
+        "recorded backup retains original content"
+    first_backup_count="$(backup_count)"
+
+    create_symlinks
+
+    second_backup_count="$(backup_count)"
+    assert_eq "$first_backup_count" "$second_backup_count" \
+        "repeat install does not create another backup"
+    assert_eq "$original_backup" "$(state_backup_for "$HOME/.bashrc")" \
+        "repeat install keeps the original backup association"
+
+    # A newer-looking directory must never influence restoration; only the
+    # backup path recorded for this destination is authoritative.
+    mkdir -p "$XDG_DATA_HOME/dotfiles/backup_99999999999999_decoy/items"
+    printf 'wrong backup\n' \
+        > "$XDG_DATA_HOME/dotfiles/backup_99999999999999_decoy/items/item_1"
+
+    mkdir -p "$HOME/.local/bin"
+    printf 'shared mise\n' > "$HOME/.local/bin/mise"
+    printf 'shared sheldon\n' > "$HOME/.local/bin/sheldon"
+
+    # shellcheck source=../uninstall.sh
+    source "$REPO_ROOT/uninstall.sh"
+    uninstall_managed_links
+
+    assert_not_exists "$XDG_CONFIG_HOME/git" \
+        "uninstall removes a link created by this installation"
+    assert_eq "original bashrc" "$(sed -n '1p' "$HOME/.bashrc")" \
+        "uninstall restores the associated original"
+    assert_not_exists "$DOTFILES_INSTALL_STATE" \
+        "successful uninstall consumes installation state"
+    assert_exists "$HOME/.local/bin/mise" \
+        "uninstall leaves a shared mise installation untouched"
+    assert_exists "$HOME/.local/bin/sheldon" \
+        "uninstall leaves a shared Sheldon installation untouched"
+)
+
+test_preexisting_matching_link_is_not_claimed() (
+    prepare_home "preexisting-home"
+    ln -s "$REPO_ROOT/zsh/.zshenv" "$HOME/.zshenv"
+
+    # shellcheck source=../install.sh
+    source "$REPO_ROOT/install.sh"
+    create_symlinks
+    # shellcheck source=../uninstall.sh
+    source "$REPO_ROOT/uninstall.sh"
+    uninstall_managed_links
+
+    assert_eq "$REPO_ROOT/zsh/.zshenv" "$(readlink "$HOME/.zshenv")" \
+        "uninstall leaves a pre-existing matching link untouched"
+)
+
+test_uninstall_refuses_replaced_link() (
+    prepare_home "replaced-home"
+    local unrelated="$HOME/unrelated-zshenv"
+    printf 'unrelated\n' > "$unrelated"
+
+    # shellcheck source=../install.sh
+    source "$REPO_ROOT/install.sh"
+    create_symlinks
+    rm "$HOME/.zshenv"
+    ln -s "$unrelated" "$HOME/.zshenv"
+
+    # shellcheck source=../uninstall.sh
+    source "$REPO_ROOT/uninstall.sh"
+    if uninstall_managed_links; then
+        printf 'FAIL: uninstall unexpectedly accepted a replaced link\n' >&2
+        exit 1
+    fi
+
+    assert_eq "$unrelated" "$(readlink "$HOME/.zshenv")" \
+        "uninstall refuses to remove an unrelated replacement link"
+    assert_exists "$DOTFILES_INSTALL_STATE" \
+        "unresolved ownership record remains available for retry"
+    if awk -F '\t' -v destination="$HOME/.zshenv" \
+        '$1 == "created" && $3 == destination { found = 1 } END { exit !found }' \
+        "$DOTFILES_INSTALL_STATE"; then
+        printf 'PASS: unresolved state identifies the refused link\n'
+    else
+        printf 'FAIL: unresolved state does not identify refused link\n' >&2
+        exit 1
+    fi
+)
+
+test_local_checkout_detection_ignores_remote_url
+test_install_repeat_and_restore
+test_preexisting_matching_link_is_not_claimed
+test_uninstall_refuses_replaced_link

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,8 +4,9 @@
 set -euo pipefail
 
 # --- Configuration ---
-XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-"$HOME/.config"}
-XDG_DATA_HOME=${XDG_DATA_HOME:-"$HOME/.local/share"}
+XDG_STATE_HOME=${XDG_STATE_HOME:-"$HOME/.local/state"}
+DOTFILES_STATE_DIR=${DOTFILES_STATE_DIR:-"$XDG_STATE_HOME/dotfiles"}
+DOTFILES_INSTALL_STATE=${DOTFILES_INSTALL_STATE:-"$DOTFILES_STATE_DIR/install-state.tsv"}
 
 # --- Helper for logging ---
 log_info() {
@@ -18,208 +19,115 @@ log_error() {
 
 # --- Main functions ---
 
-remove_symlinks() {
-    log_info "Removing symbolic links..."
+append_state_record() {
+    local state_file=$1
+    local status=$2
+    local source=$3
+    local destination=$4
+    local backup=$5
 
-    local symlinks=(
-        "$XDG_CONFIG_HOME/git"
-        "$XDG_CONFIG_HOME/tmux"
-        "$XDG_CONFIG_HOME/sheldon"
-        "$XDG_CONFIG_HOME/zsh"
-        "$XDG_CONFIG_HOME/mise"
-        "$XDG_CONFIG_HOME/gh"
-        "$XDG_CONFIG_HOME/npm"
-        "$XDG_CONFIG_HOME/iterm2"
-        "$XDG_CONFIG_HOME/bash"
-        "$HOME/.bashrc"
-        "$HOME/.bash_profile"
-        "$HOME/.zshenv"
-    )
-
-    for link in "${symlinks[@]}"; do
-        if [ -L "$link" ]; then
-            rm "$link"
-            log_info "Removed symlink: $link"
-        else
-            log_info "Symlink not found, skipping: $link"
-        fi
-    done
+    printf '%s\t%s\t%s\t%s\n' "$status" "$source" "$destination" "$backup" >> "$state_file"
 }
 
-restore_backup() {
-    log_info "Searching for backups..."
-    local backup_parent_dir="$XDG_DATA_HOME/dotfiles"
-    if [ ! -d "$backup_parent_dir" ]; then
-        log_info "No backup directories found."
-        return
+uninstall_managed_links() {
+    log_info "Removing links recorded by the installer..."
+
+    if [ ! -r "$DOTFILES_INSTALL_STATE" ]; then
+        log_info "No installation state found; no links will be removed."
+        return 0
     fi
 
-    local backup_dirs=("$backup_parent_dir"/backup_*/)
-    if [ ${#backup_dirs[@]} -eq 0 ] || [ ! -d "${backup_dirs}" ]; then
-        log_info "No backup directories found."
-        return
-    fi
+    local state_tmp
+    state_tmp="$(mktemp "$DOTFILES_STATE_DIR/.uninstall-state.XXXXXX")"
+    chmod 600 "$state_tmp"
+    printf 'version\t1\n' > "$state_tmp"
 
-    local backup_to_restore
-    if [ "${CI-}" = "true" ]; then
-        # In CI, automatically select the latest backup
-        backup_to_restore=$(ls -td -- "$backup_parent_dir"/backup_*/ | head -n 1)
-    else
-        # In interactive mode, let the user choose
-        log_info "Available backups:"
-        select backup_dir in "${backup_dirs[@]}" "Skip restoration"; do
-            if [ -z "$backup_dir" ]; then
-                log_error "Invalid selection."
+    local incomplete=0
+    local status source destination backup
+    while IFS=$'\t' read -r status source destination backup; do
+        case "$status" in
+            version)
                 continue
-            fi
-            if [ "$backup_dir" = "Skip restoration" ]; then
-                log_info "Skipping restoration."
-                return
-            fi
-            if [ -d "$backup_dir" ]; then
-                backup_to_restore="$backup_dir"
-                break
-            fi
-            log_error "Invalid selection."
-        done
-    fi
-
-    if [ -n "$backup_to_restore" ]; then
-        log_info "Restoring files from: $backup_to_restore"
-        # Use -i for safety in interactive mode
-        local cp_opts="-r"
-        [ "${CI-}" != "true" ] && cp_opts="-ri"
-
-        # As we preserved the structure, we can copy the whole backup content to HOME
-        # The backup contains subdirectories like .config, etc.
-        if [ -d "$backup_to_restore" ]; then
-            # shellcheck disable=SC2086
-            cp $cp_opts "$backup_to_restore"/. "$HOME/"
-            log_info "Restoration from backup completed."
-        else
-            log_error "Backup directory not found: $backup_to_restore"
-        fi
-    fi
-}
-
-prompt_yes_no() {
-    while true; do
-        read -r -p "$1 [y/N]: " answer
-        case "$answer" in
-            [Yy]*) return 0 ;;
-            [Nn]*|"" ) return 1 ;;
-            *) log_error "Invalid input." ;;
-        esac
-    done
-}
-
-uninstall_sheldon() {
-    log_info "Checking for sheldon installation..."
-    local sheldon_path="$HOME/.local/bin/sheldon"
-    if [ -f "$sheldon_path" ]; then
-        # In CI, uninstall without prompting.
-        if [ "${CI-}" = "true" ] || prompt_yes_no "Do you want to uninstall sheldon?"; then
-            log_info "Uninstalling sheldon..."
-            rm "$sheldon_path"
-            # Attempt to remove the parent directory if it's empty
-            if [ -z "$(ls -A "$HOME/.local/bin")" ]; then
-                log_info "Removing empty directory: $HOME/.local/bin"
-                rmdir "$HOME/.local/bin"
-            fi
-            if [ -z "$(ls -A "$HOME/.local")" ]; then
-                log_info "Removing empty directory: $HOME/.local"
-                rmdir "$HOME/.local"
-            fi
-            log_info "sheldon uninstalled."
-        else
-            log_info "Skipping sheldon uninstallation."
-        fi
-    else
-        log_info "sheldon is not installed."
-    fi
-}
-
-uninstall_mise() {
-    log_info "Checking for mise installation..."
-    local mise_path="$HOME/.local/bin/mise"
-
-    # Check for the existence of the mise binary as the primary indicator of installation.
-    if [ ! -f "$mise_path" ]; then
-        log_info "mise binary not found at $mise_path. Skipping uninstallation."
-        return
-    fi
-
-    if [ "${CI-}" = "true" ] || prompt_yes_no "Do you want to uninstall mise?"; then
-        # Attempt to use the official uninstaller first if the command is available.
-        if command -v mise &> /dev/null; then
-            log_info "Uninstalling mise using 'mise implode'..."
-            if mise implode; then
-                log_info "mise uninstalled successfully via 'mise implode'."
-                # implode should remove the binary, but we double-check and remove if it's still there.
-                if [ -f "$mise_path" ]; then
-                    rm "$mise_path"
-                fi
-                log_info "mise uninstallation complete."
-                return
-            else
-                log_error "'mise implode' command failed. Proceeding with manual removal."
-            fi
-        else
-            log_info "'mise' command not found in PATH. Proceeding with manual removal."
-        fi
-
-        # Fallback to manual removal.
-        log_info "Attempting to manually remove mise files..."
-
-        # Remove the binary
-        log_info "Removing mise binary: $mise_path"
-        rm "$mise_path"
-
-        # Remove directories
-        local mise_data_dir=${MISE_DATA_DIR:-"$XDG_DATA_HOME/mise"}
-        local mise_state_dir=${MISE_STATE_DIR:-"$HOME/.local/state/mise"}
-        local mise_config_dir=${MISE_CONFIG_DIR:-"$XDG_CONFIG_HOME/mise"}
-        local mise_cache_dir
-
-        case "$(uname -s)" in
-            Linux*)
-                mise_cache_dir=${MISE_CACHE_DIR:-"$HOME/.cache/mise"}
                 ;;
-            Darwin*)
-                mise_cache_dir=${MISE_CACHE_DIR:-"$HOME/Library/Caches/mise"}
+            preexisting)
+                log_info "Leaving pre-existing link untouched: $destination"
+                continue
+                ;;
+            created)
                 ;;
             *)
-                mise_cache_dir=""
+                log_error "Keeping an unrecognized installation-state record."
+                append_state_record "$state_tmp" "$status" "$source" "$destination" "$backup"
+                incomplete=1
+                continue
                 ;;
         esac
 
-        local dirs_to_remove=("$mise_data_dir" "$mise_state_dir" "$mise_config_dir")
-        if [ -n "$mise_cache_dir" ]; then
-            dirs_to_remove+=("$mise_cache_dir")
+        if [ "$backup" != "-" ] \
+            && [ ! -e "$backup" ] \
+            && [ ! -L "$backup" ]; then
+            log_error "Refusing to remove $destination because its recorded backup is missing: $backup"
+            append_state_record "$state_tmp" "$status" "$source" "$destination" "$backup"
+            incomplete=1
+            continue
         fi
 
-        for dir in "${dirs_to_remove[@]}"; do
-            if [ -d "$dir" ]; then
-                log_info "Removing directory: $dir"
-                rm -rf "$dir"
-            else
-                log_info "Directory not found, skipping: $dir"
+        if [ -L "$destination" ]; then
+            if [ "$(readlink "$destination")" != "$source" ]; then
+                log_error "Refusing to remove a link not owned by this installation: $destination"
+                append_state_record "$state_tmp" "$status" "$source" "$destination" "$backup"
+                incomplete=1
+                continue
             fi
-        done
+            rm "$destination"
+            log_info "Removed managed link: $destination"
+        elif [ -e "$destination" ]; then
+            log_error "Refusing to replace an unmanaged path: $destination"
+            append_state_record "$state_tmp" "$status" "$source" "$destination" "$backup"
+            incomplete=1
+            continue
+        else
+            log_info "Managed link already absent: $destination"
+        fi
 
-        log_info "mise manual uninstallation process completed."
-    else
-        log_info "Skipping mise uninstallation."
+        if [ "$backup" != "-" ]; then
+            if ! mkdir -p "$(dirname "$destination")"; then
+                log_error "Could not create the parent directory for: $destination"
+                append_state_record "$state_tmp" "$status" "$source" "$destination" "$backup"
+                incomplete=1
+                continue
+            fi
+            if mv "$backup" "$destination"; then
+                log_info "Restored original path: $destination"
+            else
+                log_error "Could not restore the recorded backup for: $destination"
+                append_state_record "$state_tmp" "$status" "$source" "$destination" "$backup"
+                incomplete=1
+            fi
+        fi
+    done < "$DOTFILES_INSTALL_STATE"
+
+    if [ "$incomplete" -eq 0 ]; then
+        rm "$state_tmp" "$DOTFILES_INSTALL_STATE"
+        log_info "Installation state removed."
+        return 0
     fi
+
+    mv "$state_tmp" "$DOTFILES_INSTALL_STATE"
+    return 1
 }
 
 main() {
-    remove_symlinks
-    restore_backup
-    uninstall_sheldon
-    uninstall_mise
+    if uninstall_managed_links; then
+        log_info "mise and Sheldon installations were left untouched."
+        log_info "✅ Uninstallation completed successfully!"
+        return
+    fi
 
-    log_info "✅ Uninstallation completed successfully!"
+    log_error "Uninstallation is incomplete; unresolved entries remain in $DOTFILES_INSTALL_STATE"
+    return 1
 }
 
-main
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    main "$@"
+fi


### PR DESCRIPTION
## What changed

- detect a local checkout by Git worktree identity instead of an exact remote URL, so SSH remotes and forks do not trigger a nested clone
- make symlink installation idempotent and preserve the original backup association across repeat runs
- record link ownership and exact backup paths in `$XDG_STATE_HOME/dotfiles/install-state.tsv`
- remove only installer-owned links whose current target still matches the recorded target
- restore each original from its recorded backup instead of selecting the newest backup directory
- leave pre-existing or user-replaced links, mise, and Sheldon untouched
- document the lifecycle and add isolated regression coverage

## Why

The previous installer backed up already-correct links on every run. That could replace the real original backup with a dotfiles symlink, while the uninstaller deleted any symlink at known destinations and restored an arbitrarily selected backup. It also treated non-HTTPS/fork checkouts as standalone scripts and removed shared tool installations.

## Impact

Repeat installs no longer churn links or backups. Uninstall is ownership-aware and fails safely when a managed destination has been replaced, retaining the unresolved state for a later retry. Existing matching links are never claimed by a new installation.

## Validation

- `bash -n install.sh uninstall.sh tests/test_install_lifecycle.sh`
- `./tests/test_install_lifecycle.sh`
- `./tests/test_shell_startup.sh`
- `./tests/test_update_script.sh`
- `git diff --check`

The lifecycle test uses temporary HOME/XDG directories and does not invoke network access, package managers, sudo, or chsh.