### PR TITLE
Harden local secrets and global ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,36 @@ curl -fsSL https://raw.githubusercontent.com/akgm3i/.dotfiles/master/install.sh 
 
 `install.sh` を実行した際のバックアップを復元する。
 
+## ローカル秘密設定
+
+API tokenなどの秘密値はリポジトリ内に置かず、
+`${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/secrets.zsh` で管理する。
+初回は次のように所有者だけがアクセスできるファイルを作成する。
+
+```bash
+secret_dir="${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles"
+mkdir -p "$secret_dir"
+chmod 700 "$secret_dir"
+touch "$secret_dir/secrets.zsh"
+chmod 600 "$secret_dir/secrets.zsh"
+"${EDITOR:-vi}" "$secret_dir/secrets.zsh"
+```
+
+ファイルには、シェルへ公開する値だけを `export NAME='value'` の形式で記載する。
+GitHub CLIのtokenも `export GH_TOKEN='value'` として同じファイルで管理できる。
+
+Zshはこのファイルが通常ファイルであり、現在のユーザーが所有し、
+group/other権限を持たない場合だけ読み込む。symlinkや権限の緩いファイルは、
+秘密値を表示せず警告して読み飛ばす。
+
+従来の `$ZDOTDIR/*secret*.zsh` は誤commit防止のためignoreを継続するが、
+起動時には読み込まれない。内容を上記ファイルへ手動で移し、
+動作確認後に旧ファイルを削除する。
+
+`gh/hosts.yml` にtokenが保存されている場合は、`GH_TOKEN` への移行後に
+`gh auth status` を確認してから旧ファイルをリポジトリ外へ退避または削除する。
+移行中の誤commitを防ぐため、`gh/hosts.yml` のignoreは継続する。
+
 ## MOTD
 
 `motd` を実行すると、端末とdotfilesのローカル情報を表示する。

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
-- [ ] Protect sensitive tokens (e.g., GitHub) via external secrets or environment, not committed files.
 - [ ] Ensure XDG_RUNTIME_DIR (/home/akgm3i/.temp) is created (install script) before tmux uses it.
 - [ ] Respect externally supplied DOTPATH in .zshenv (use exported default).

--- a/gh/.gitignore
+++ b/gh/.gitignore
@@ -1,1 +1,3 @@
+# Prevent credentials created by gh from being committed during migration to
+# GH_TOKEN in the repository-external secrets file.
 /hosts.yml

--- a/git/ignore
+++ b/git/ignore
@@ -142,8 +142,6 @@ fabric.properties
 
 
 # ---- MicrosoftOffice ----
-*.tmp
-
 # Word temporary
 ~$*.doc*
 

--- a/tests/test_local_security.sh
+++ b/tests/test_local_security.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ZSH_BIN="$(command -v zsh || true)"
+if [ -z "$ZSH_BIN" ]; then
+  printf 'SKIP: zsh is not installed\n'
+  exit 0
+fi
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local test_name="$3"
+
+  if [ "$expected" = "$actual" ]; then
+    printf 'PASS: %s\n' "$test_name"
+  else
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' \
+      "$test_name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local value="$1"
+  local expected="$2"
+  local test_name="$3"
+
+  if grep -qF -- "$expected" <<< "$value"; then
+    printf 'PASS: %s\n' "$test_name"
+  else
+    printf 'FAIL: %s\nmissing: %s\nvalue: %s\n' \
+      "$test_name" "$expected" "$value" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local value="$1"
+  local unexpected="$2"
+  local test_name="$3"
+
+  if grep -qF -- "$unexpected" <<< "$value"; then
+    printf 'FAIL: %s\nunexpected: %s\nvalue: %s\n' \
+      "$test_name" "$unexpected" "$value" >&2
+    exit 1
+  fi
+  printf 'PASS: %s\n' "$test_name"
+}
+
+run_secret_loader() {
+  local config_home="$1"
+  local zdotdir="$2"
+
+  HOME="$TEST_DIR/home" XDG_CONFIG_HOME="$config_home" ZDOTDIR="$zdotdir" \
+    SECRET_LOADER="$REPO_ROOT/zsh/99_deinit.zsh" \
+    "$ZSH_BIN" -fc \
+    'unset DOTFILES_TEST_SECRET
+     source "$SECRET_LOADER"
+     print -r -- "${DOTFILES_TEST_SECRET:-not-loaded}"' 2>&1
+}
+
+test_private_secret_is_loaded() {
+  local config_home="$TEST_DIR/private-config"
+  local zdotdir="$TEST_DIR/private-zdotdir"
+  local secret_file="$config_home/dotfiles/secrets.zsh"
+  mkdir -p "${secret_file%/*}" "$zdotdir"
+  printf '%s\n' "export DOTFILES_TEST_SECRET='loaded'" > "$secret_file"
+  chmod 600 "$secret_file"
+
+  assert_eq "loaded" "$(run_secret_loader "$config_home" "$zdotdir")" \
+    "owner-only external secret is loaded"
+}
+
+test_public_secret_is_rejected_without_leaking() {
+  local config_home="$TEST_DIR/public-config"
+  local zdotdir="$TEST_DIR/public-zdotdir"
+  local secret_file="$config_home/dotfiles/secrets.zsh"
+  local output
+  mkdir -p "${secret_file%/*}" "$zdotdir"
+  printf '%s\n' "export DOTFILES_TEST_SECRET='must-not-leak'" > "$secret_file"
+  chmod 644 "$secret_file"
+
+  output="$(run_secret_loader "$config_home" "$zdotdir")"
+  assert_contains "$output" "run chmod 600" \
+    "group-readable external secret is rejected"
+  assert_contains "$output" "not-loaded" \
+    "rejected external secret is not sourced"
+  assert_not_contains "$output" "must-not-leak" \
+    "warning does not expose the rejected secret"
+}
+
+test_symlink_secret_is_rejected() {
+  local config_home="$TEST_DIR/symlink-config"
+  local zdotdir="$TEST_DIR/symlink-zdotdir"
+  local secret_file="$config_home/dotfiles/secrets.zsh"
+  local target="$TEST_DIR/secret-target.zsh"
+  local output
+  mkdir -p "${secret_file%/*}" "$zdotdir"
+  printf '%s\n' "export DOTFILES_TEST_SECRET='symlink-value'" > "$target"
+  chmod 600 "$target"
+  ln -s "$target" "$secret_file"
+
+  output="$(run_secret_loader "$config_home" "$zdotdir")"
+  assert_contains "$output" "expected a regular, non-symlink file" \
+    "symlink secret is rejected"
+  assert_contains "$output" "not-loaded" \
+    "symlink secret is not sourced"
+  assert_not_contains "$output" "symlink-value" \
+    "warning does not expose the symlinked secret"
+}
+
+test_legacy_secret_warns_without_loading() {
+  local config_home="$TEST_DIR/legacy-config"
+  local zdotdir="$TEST_DIR/legacy-zdotdir"
+  local legacy_file="$zdotdir/my-secret.zsh"
+  local output
+  mkdir -p "$config_home" "$zdotdir"
+  printf '%s\n' "export DOTFILES_TEST_SECRET='legacy-value'" > "$legacy_file"
+  chmod 600 "$legacy_file"
+
+  output="$(run_secret_loader "$config_home" "$zdotdir")"
+  assert_contains "$output" "repository-local secret files are no longer loaded" \
+    "legacy secret emits a migration warning"
+  assert_contains "$output" "not-loaded" \
+    "legacy secret is not sourced"
+  assert_not_contains "$output" "legacy-value" \
+    "migration warning does not expose the legacy secret"
+}
+
+test_global_ignore_keeps_generic_tmp_visible() {
+  local excludes_file="$REPO_ROOT/git/ignore"
+
+  if git -C "$REPO_ROOT" -c core.excludesFile="$excludes_file" \
+    check-ignore -q -- "dotfiles-security-source.tmp"; then
+    printf 'FAIL: generic .tmp source is globally ignored\n' >&2
+    exit 1
+  fi
+  printf 'PASS: generic .tmp source remains visible to git\n'
+
+  if git -C "$REPO_ROOT" -c core.excludesFile="$excludes_file" \
+    check-ignore -q -- '~$dotfiles-security-report.docx'; then
+    printf 'PASS: Microsoft Office temporary file remains ignored\n'
+  else
+    printf 'FAIL: Microsoft Office temporary file is not ignored\n' >&2
+    exit 1
+  fi
+}
+
+test_migration_files_remain_ignored() {
+  if git -C "$REPO_ROOT" check-ignore -q -- "zsh/local-secret.zsh"; then
+    printf 'PASS: legacy Zsh secret remains guarded from commits\n'
+  else
+    printf 'FAIL: legacy Zsh secret is not ignored during migration\n' >&2
+    exit 1
+  fi
+
+  if git -C "$REPO_ROOT" check-ignore -q -- "gh/hosts.yml"; then
+    printf 'PASS: GitHub hosts credentials remain guarded from commits\n'
+  else
+    printf 'FAIL: GitHub hosts credentials are not ignored during migration\n' >&2
+    exit 1
+  fi
+}
+
+test_private_secret_is_loaded
+test_public_secret_is_rejected_without_leaking
+test_symlink_secret_is_rejected
+test_legacy_secret_warns_without_loading
+test_global_ignore_keeps_generic_tmp_visible
+test_migration_files_remain_ignored

--- a/tests/test_motd.sh
+++ b/tests/test_motd.sh
@@ -52,12 +52,14 @@ make_stubs() {
 }
 
 test_startup_is_opt_in() {
-  local secret_dir output
-  secret_dir="$TEST_DIR/secrets"
-  mkdir -p "$secret_dir"
+  local config_home zdotdir output
+  config_home="$TEST_DIR/config"
+  zdotdir="$TEST_DIR/zdotdir"
+  mkdir -p "$config_home" "$zdotdir"
 
   output="$(
-    ZDOTDIR="$secret_dir" MOTD_DEINIT="$REPO_ROOT/zsh/99_deinit.zsh" \
+    XDG_CONFIG_HOME="$config_home" ZDOTDIR="$zdotdir" \
+      MOTD_DEINIT="$REPO_ROOT/zsh/99_deinit.zsh" \
       "$ZSH_BIN" -f -ic \
       'unset DOTFILES_MOTD_ON_START
        motd() { print -r -- called; }
@@ -66,7 +68,8 @@ test_startup_is_opt_in() {
   assert_eq "" "$output" "interactive startup does not run motd by default"
 
   output="$(
-    ZDOTDIR="$secret_dir" DOTFILES_MOTD_ON_START=1 \
+    XDG_CONFIG_HOME="$config_home" ZDOTDIR="$zdotdir" \
+      DOTFILES_MOTD_ON_START=1 \
       MOTD_DEINIT="$REPO_ROOT/zsh/99_deinit.zsh" \
       "$ZSH_BIN" -f -ic \
       'motd() { print -r -- called; }

--- a/zsh/.gitignore
+++ b/zsh/.gitignore
@@ -1,2 +1,2 @@
-# ignore secret
+# Migration guard only. Repository-local secret files are never sourced.
 /*secret*.zsh

--- a/zsh/99_deinit.zsh
+++ b/zsh/99_deinit.zsh
@@ -2,15 +2,50 @@
 # deinitialize.
 #
 
-# Source any secret files.
+# Load local secrets from outside the repository.
 ()
 {
-    local f secret_dir
-    secret_dir="${ZDOTDIR:-${DOTPATH:-$HOME/.dotfiles}/zsh}"
-    for f in "${secret_dir}"/*secret*.zsh(N-.)
-    do
-        source "$f"
-    done
+    local secret_file="${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/secrets.zsh"
+    local legacy_dir="${ZDOTDIR:-${DOTPATH:-$HOME/.dotfiles}/zsh}"
+    local -a legacy_files
+    local -A secret_stat
+
+    legacy_files=("${legacy_dir}"/*secret*.zsh(N-.))
+    if (( ${#legacy_files} > 0 )); then
+        print -ru2 -- \
+            "dotfiles: repository-local secret files are no longer loaded; move them to $secret_file"
+    fi
+
+    [[ -e "$secret_file" || -L "$secret_file" ]] || return
+
+    if [[ -L "$secret_file" || ! -f "$secret_file" ]]; then
+        print -ru2 -- \
+            "dotfiles: not loading $secret_file: expected a regular, non-symlink file"
+        return
+    fi
+    if [[ ! -O "$secret_file" ]]; then
+        print -ru2 -- \
+            "dotfiles: not loading $secret_file: file must be owned by the current user"
+        return
+    fi
+    if [[ ! -r "$secret_file" ]]; then
+        print -ru2 -- \
+            "dotfiles: not loading $secret_file: file is not readable"
+        return
+    fi
+    if ! zmodload -F zsh/stat b:zstat 2>/dev/null \
+        || ! zstat -H secret_stat -- "$secret_file" 2>/dev/null; then
+        print -ru2 -- \
+            "dotfiles: not loading $secret_file: unable to verify file permissions"
+        return
+    fi
+    if (( (secret_stat[mode] & 077) != 0 )); then
+        print -ru2 -- \
+            "dotfiles: not loading $secret_file: run chmod 600 on this file"
+        return
+    fi
+
+    source "$secret_file"
 }
 
 # The local system summary is disabled by default. Run `motd` explicitly, or


### PR DESCRIPTION
## Summary

- Load shell secrets only from `${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/secrets.zsh`, outside the repository.
- Refuse non-regular files, symlinks, files owned by another user, unreadable files, and files with group/other permissions.
- Warn about legacy `$ZDOTDIR/*secret*.zsh` files without sourcing them or printing their contents.
- Document creation, permissions, legacy migration, and moving GitHub CLI authentication to `GH_TOKEN`.
- Retain narrow ignore guards for legacy Zsh secrets and `gh/hosts.yml` during migration so credentials cannot be accidentally staged.
- Remove the global `*.tmp` pattern while retaining explicit Microsoft Office temporary-file patterns.
- Add regression tests for accepted/rejected secret files, non-disclosure in warnings, migration guards, and `.tmp` visibility.

## Why

The previous loader sourced every repository-local filename matching `*secret*.zsh` without checking ownership or permissions. Because the Zsh and GitHub configuration directories are linked into the repository, ignored credential files could remain inside the working tree and be readable by other local users. Separately, the global `*.tmp` rule could hide legitimate source or test fixtures from Git.

## Impact and migration

Existing repository-local secret files are deliberately no longer loaded. Move their exports into the documented external file and run `chmod 600` before relying on them. For GitHub CLI, define `GH_TOKEN` there, verify with `gh auth status`, and then move or remove the old `gh/hosts.yml`.

Permission checks use Zsh's bundled `zsh/stat` module, avoiding Linux/macOS differences in the external `stat` command. The implementation checks the secret file itself and documents a `0700` parent directory; it does not add a larger installer migration or recursively validate the directory hierarchy. Credential files are not moved automatically because automation would have to read or mutate live authentication material.

## Stack

This PR is based on #13 (`agent/lightweight-motd`) and contains only the follow-up secret and ignore hardening commit.

## Validation

- `./tests/test_local_security.sh`
- `./tests/test_motd.sh`
- `./tests/test_shell_startup.sh`
- `./tests/test_update_script.sh`
- `zsh -n bin/motd zsh/*.zsh`
- `bash -n tests/*.sh`
- `sh -n tests/fixtures/motd-command-stub.sh`
- `git diff --check`