### PR TITLE
解消済みの dotfiles TODO を削除

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,0 @@
-- [ ] Ensure XDG_RUNTIME_DIR (/home/akgm3i/.temp) is created (install script) before tmux uses it.
-- [ ] Respect externally supplied DOTPATH in .zshenv (use exported default).


### PR DESCRIPTION
## What

残っていた `TODO.md` を削除します。

## Why

未完了として残っていた項目はすべて解消済みです。

- `XDG_RUNTIME_DIR` の作成: 現行 `shell/env.sh` と起動テストで対応済み
- 外部 `DOTPATH` とsymlink解決: 現行起動処理とテストで対応済み
- MOTDの更新確認/起動遅延: #13でローカル・opt-in化
- 秘密値のリポジトリ外配置: #19で安全な外部ファイルへ移行

#19では同PRが解消する項目をすでに除去しているため、このPRの差分は残る2件のみです。

## Dependency

#13 → #19 → このPRの順にstackしています。#19のマージ後、baseを `master` へ変更できます。

## Checks

- #19上の全テスト
- Bash/Zsh構文検査
- `git diff --check`